### PR TITLE
Boost indigo topo visibility and remove volt debug mode

### DIFF
--- a/public/topo-indigo.svg
+++ b/public/topo-indigo.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800" role="img" aria-label="Indigo topographic pattern">
-  <rect width="800" height="800" fill="#0b1026" />
-  <g fill="none" stroke="#1b2554" stroke-width="1.2" opacity="0.72">
+  <rect width="800" height="800" fill="#0e1b4d" />
+  <g fill="none" stroke="#a9bbff" stroke-width="1.6" opacity="0.24">
     <path d="M-40 90C60 20 180 25 290 78s215 70 320 35 196-30 280 18" />
     <path d="M-60 150C45 80 175 85 296 136s232 70 340 33 201-30 288 24" />
     <path d="M-30 210c102-66 226-61 350-8s236 67 343 29 194-27 273 26" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,7 +1,7 @@
 :root {
   --aicv-indigo: #0e1b4d;
   --aicv-volt: #c7ff2e;
-  --aicv-page-bg: #0b1026;
+  --aicv-page-bg: #0e1b4d;
   --aicv-surface: rgba(255, 255, 255, 0.92);
   --aicv-border: rgba(255, 255, 255, 0.2);
   --aicv-button-text: #ffffff;
@@ -10,8 +10,8 @@
 body {
   background-color: var(--aicv-indigo);
   background-image:
-    radial-gradient(1200px 600px at 20% 10%, rgba(255, 255, 255, 0.1), transparent 55%),
-    radial-gradient(900px 500px at 80% 30%, rgba(199, 255, 46, 0.08), transparent 60%),
+    radial-gradient(1100px 560px at 18% 12%, rgba(255, 255, 255, 0.14), transparent 58%),
+    radial-gradient(900px 520px at 80% 28%, rgba(199, 255, 46, 0.1), transparent 62%),
     url("/topo-indigo.svg");
   background-size: cover, cover, cover;
   background-position: center, center, center;
@@ -83,10 +83,4 @@ a[role="button"]:hover {
   background: var(--aicv-volt);
   border-color: var(--aicv-volt);
   color: #111111;
-}
-
-/* TEMP: Volt Debug Mode (remove once verified) */
-body {
-  background-color: #c7ff2e !important;
-  background-image: none !important;
 }


### PR DESCRIPTION
## Summary\n- remove temporary volt debug override\n- keep bluer indigo base token (#0E1B4D)\n- tune body background gradients/blend so topo pattern reads clearly\n- increase topo SVG line visibility (stroke color/width/opacity)\n- keep header/nav and primary button global styling on indigo/volt\n\n## Validation\n- npm run build