### PR TITLE
Fix city dropdown 404s and sticky footer layout

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -62,15 +62,15 @@ const siteJsonLd = {
             <details class="nav-dropdown">
               <summary>Cities</summary>
               <div class="dropdown-menu">
-                <a href="/cities/palm-springs">Palm Springs</a>
-                <a href="/cities/desert-hot-springs">Desert Hot Springs</a>
-                <a href="/cities/cathedral-city">Cathedral City</a>
-                <a href="/cities/rancho-mirage">Rancho Mirage</a>
-                <a href="/cities/palm-desert">Palm Desert</a>
-                <a href="/cities/indian-wells">Indian Wells</a>
-                <a href="/cities/indio">Indio</a>
-                <a href="/cities/la-quinta">La Quinta</a>
-                <a href="/cities/coachella">Coachella</a>
+                <a href="/cities">Palm Springs</a>
+                <a href="/cities">Desert Hot Springs</a>
+                <a href="/cities">Cathedral City</a>
+                <a href="/cities">Rancho Mirage</a>
+                <a href="/cities">Palm Desert</a>
+                <a href="/cities">Indian Wells</a>
+                <a href="/cities">Indio</a>
+                <a href="/cities">La Quinta</a>
+                <a href="/cities">Coachella</a>
                 <a href="/cities">All Cities</a>
               </div>
             </details>
@@ -109,6 +109,9 @@ const siteJsonLd = {
 
   :global(body) {
     margin: 0;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
     font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
     background: var(--aicv-page-bg, #f7f8fa);
     color: #1a1a1a;
@@ -230,6 +233,7 @@ const siteJsonLd = {
   }
 
   main {
+    flex: 1;
     max-width: 72rem;
     margin: 0 auto;
     padding: 2rem 1.25rem 3rem;


### PR DESCRIPTION
## Summary\n- route all Cities dropdown entries to /cities to avoid city-page 404s\n- make BaseLayout body a min-height flex column and set main to flex: 1\n- keeps footer pinned to bottom on short/empty pages\n\n## Validation\n- npm run build