### PR TITLE
Fix Cities dropdown links to avoid 404s

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -62,15 +62,15 @@ const siteJsonLd = {
             <details class="nav-dropdown">
               <summary>Cities</summary>
               <div class="dropdown-menu">
-                <a href="/cities/palm-springs">Palm Springs</a>
-                <a href="/cities/desert-hot-springs">Desert Hot Springs</a>
-                <a href="/cities/cathedral-city">Cathedral City</a>
-                <a href="/cities/rancho-mirage">Rancho Mirage</a>
-                <a href="/cities/palm-desert">Palm Desert</a>
-                <a href="/cities/indian-wells">Indian Wells</a>
-                <a href="/cities/indio">Indio</a>
-                <a href="/cities/la-quinta">La Quinta</a>
-                <a href="/cities/coachella">Coachella</a>
+                <a href="/cities">Palm Springs</a>
+                <a href="/cities">Desert Hot Springs</a>
+                <a href="/cities">Cathedral City</a>
+                <a href="/cities">Rancho Mirage</a>
+                <a href="/cities">Palm Desert</a>
+                <a href="/cities">Indian Wells</a>
+                <a href="/cities">Indio</a>
+                <a href="/cities">La Quinta</a>
+                <a href="/cities">Coachella</a>
                 <a href="/cities">All Cities</a>
               </div>
             </details>


### PR DESCRIPTION
## Summary\n- updates Cities dropdown links in BaseLayout\n- keeps city labels the same\n- routes each city item to /cities so no city click hits a 404\n\n## Scope\n- minimal diff in one file