### PR TITLE
Clean up top nav labels and grouping

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -55,7 +55,7 @@ const siteJsonLd = {
         <a href="/" class="brand">AI Coachella Valley (AICV)</a>
         <div class="header-right">
           <nav aria-label="Primary">
-            <a href="/marketplace">AICV Suggests</a>
+            <a href="/marketplace">Marketplace</a>
             <a href="/briefs">Briefs</a>
             <a href="/state-of-ai">State of AI</a>
             <a href="/events">Events</a>
@@ -80,9 +80,14 @@ const siteJsonLd = {
                 <a href="/tools/aio">AI Visibility Checkup</a>
               </div>
             </details>
-            <a href="/about">About</a>
-            <a href="/submit">Submit a Brief</a>
-            <a href="/contact">Contact</a>
+            <details class="nav-dropdown">
+              <summary>About</summary>
+              <div class="dropdown-menu">
+                <a href="/about">About</a>
+                <a href="/submit">Submit a Brief</a>
+                <a href="/contact">Contact</a>
+              </div>
+            </details>
           </nav>
           <a href="/#subscribe" class="utility-link">Subscribe</a>
         </div>


### PR DESCRIPTION
## Summary\n- rename top nav label from "AICV Suggests" to "Marketplace" (same link target)\n- remove top-level "Submit a Brief" and "Contact" links\n- convert About into a dropdown with: About, Submit a Brief, Contact\n- keep Subscribe as a top-level utility link\n- footer already includes "Submit a Brief" link\n\n## Scope\n- minimal diff in BaseLayout only\n\n## Validation\n- npm run build