### PR TITLE
Add Playwright site crawl audit + report tooling

### DIFF
--- a/.github/workflows/site-audit.yml
+++ b/.github/workflows/site-audit.yml
@@ -1,0 +1,43 @@
+name: Site Audit
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run site audit
+        env:
+          SITE_URL: ${{ vars.SITE_URL }}
+        run: |
+          if [ -z "$SITE_URL" ]; then
+            SITE_URL="https://www.aicoachellavalley.com"
+          fi
+          SITE_URL="$SITE_URL" npm run audit:site
+
+      - name: Upload site audit artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-audit-report
+          path: |
+            reports/site-audit.md
+            reports/screenshots

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "astro": "^5.17.1"
       },
       "devDependencies": {
-        "@astrojs/vercel": "^9.0.4"
+        "@astrojs/vercel": "^9.0.4",
+        "playwright": "^1.58.2"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -4944,6 +4945,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "audit:site": "node scripts/audit-site.mjs"
   },
   "dependencies": {
     "astro": "^5.17.1"
   },
   "devDependencies": {
-    "@astrojs/vercel": "^9.0.4"
+    "@astrojs/vercel": "^9.0.4",
+    "playwright": "^1.58.2"
   }
 }

--- a/reports/site-audit.md
+++ b/reports/site-audit.md
@@ -1,0 +1,49 @@
+# Site Audit
+
+- Site: https://www.aicoachellavalley.com
+- Start URL: https://www.aicoachellavalley.com/
+- Generated: 2026-02-20T02:38:16.499Z
+- Pages visited: 20
+- Non-200 pages: 8
+
+## Top 10 broken links
+
+| URL | Status | Title | Screenshot |
+| --- | --- | --- | --- |
+| https://www.aicoachellavalley.com/blog/news | 404 | Page Not Found - AICV | [image](reports/screenshots/blog-news.png) |
+| https://www.aicoachellavalley.com/blog/images | 404 | Page Not Found - AICV | [image](reports/screenshots/blog-images.png) |
+| https://www.aicoachellavalley.com/blog/music | 404 | Page Not Found - AICV | [image](reports/screenshots/blog-music.png) |
+| https://www.aicoachellavalley.com/blog/video | 404 | Page Not Found - AICV | [image](reports/screenshots/blog-video.png) |
+| https://www.aicoachellavalley.com/blog/experiments | 404 | Page Not Found - AICV | [image](reports/screenshots/blog-experiments.png) |
+| https://www.aicoachellavalley.com/blog/local-ai-adoption-q1-2025 | 404 | Page Not Found - AICV | [image](reports/screenshots/blog-local-ai-adoption-q1-2025.png) |
+| https://www.aicoachellavalley.com/blog/desert-ai-art | 404 | Page Not Found - AICV | [image](reports/screenshots/blog-desert-ai-art.png) |
+| https://www.aicoachellavalley.com/blog/ai-event-recommendations | 404 | Page Not Found - AICV | [image](reports/screenshots/blog-ai-event-recommendations.png) |
+
+## Pages with empty content / weird footer
+
+No pages flagged.
+
+## Full crawl results
+
+| URL | Status | Title | Notes | Error |
+| --- | --- | --- | --- | --- |
+| https://www.aicoachellavalley.com/ | 200 | AICV - The Hub for AI in the Coachella Valley | - | - |
+| https://www.aicoachellavalley.com/learn | 200 | Learn - AI Education Hub \| AICV | - | - |
+| https://www.aicoachellavalley.com/events | 200 | Events - AI Community Meetups \| AICV | - | - |
+| https://www.aicoachellavalley.com/projects | 200 | Projects - AI Collaborations & Pilots \| AICV | - | - |
+| https://www.aicoachellavalley.com/marketplace | 200 | Marketplace - AI Talent & Services \| AICV | - | - |
+| https://www.aicoachellavalley.com/blog | 200 | AI Studio - Daily AI Content & Experiments \| AICV | - | - |
+| https://www.aicoachellavalley.com/about | 200 | About - Mission & Team \| AICV | - | - |
+| https://www.aicoachellavalley.com/workshop | 200 | Fall 2025 AI Workshops - Register Now \| AICV | - | - |
+| https://www.aicoachellavalley.com/synth | 200 | Synth v0.1 - AI Content Generator \| AICV | - | - |
+| https://www.aicoachellavalley.com/AIO | 200 | AIO Analysis - AI Optimization Analyzer Tool by AICV | - | - |
+| https://www.aicoachellavalley.com/docs/2025-ai-optimization-standards | 200 | 2025 AI Optimization Standards \| Complete Guide to AI Crawler Optimization | - | - |
+| https://www.aicoachellavalley.com/faq | 200 | AI Optimization FAQ - AIO Analysis Guide | - | - |
+| https://www.aicoachellavalley.com/blog/news | 404 | Page Not Found - AICV | - | - |
+| https://www.aicoachellavalley.com/blog/images | 404 | Page Not Found - AICV | - | - |
+| https://www.aicoachellavalley.com/blog/music | 404 | Page Not Found - AICV | - | - |
+| https://www.aicoachellavalley.com/blog/video | 404 | Page Not Found - AICV | - | - |
+| https://www.aicoachellavalley.com/blog/experiments | 404 | Page Not Found - AICV | - | - |
+| https://www.aicoachellavalley.com/blog/local-ai-adoption-q1-2025 | 404 | Page Not Found - AICV | - | - |
+| https://www.aicoachellavalley.com/blog/desert-ai-art | 404 | Page Not Found - AICV | - | - |
+| https://www.aicoachellavalley.com/blog/ai-event-recommendations | 404 | Page Not Found - AICV | - | - |

--- a/scripts/audit-site.mjs
+++ b/scripts/audit-site.mjs
@@ -1,0 +1,211 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { chromium } from "playwright";
+
+const siteUrl = process.env.SITE_URL;
+const maxPages = Number(process.env.AUDIT_MAX_PAGES || 500);
+
+if (!siteUrl) {
+  console.error("SITE_URL is required. Example: SITE_URL=https://www.aicoachellavalley.com npm run audit:site");
+  process.exit(1);
+}
+
+const start = new URL(siteUrl);
+const origin = start.origin;
+const startUrl = normalizeUrl(start.href, start.href);
+
+const reportsDir = path.resolve("reports");
+const screenshotsDir = path.join(reportsDir, "screenshots");
+const reportPath = path.join(reportsDir, "site-audit.md");
+
+await fs.mkdir(screenshotsDir, { recursive: true });
+
+const queue = [startUrl];
+const enqueued = new Set(queue);
+const visited = new Set();
+const results = [];
+
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext({
+  ignoreHTTPSErrors: true,
+  viewport: { width: 1440, height: 900 },
+});
+const page = await context.newPage();
+
+while (queue.length > 0 && visited.size < maxPages) {
+  const currentUrl = queue.shift();
+  if (!currentUrl || visited.has(currentUrl)) continue;
+  visited.add(currentUrl);
+
+  let status = "ERR";
+  let title = "";
+  let notes = [];
+  let error = "";
+  let screenshotRelPath = "";
+
+  try {
+    const response = await page.goto(currentUrl, {
+      waitUntil: "domcontentloaded",
+      timeout: 30000,
+    });
+
+    status = response?.status() ?? 0;
+    title = await page.title();
+
+    const hrefs = await page.$$eval("a[href]", (anchors) =>
+      anchors.map((a) => a.getAttribute("href")).filter(Boolean)
+    );
+
+    for (const href of hrefs) {
+      const normalized = normalizeUrl(href, currentUrl);
+      if (!normalized) continue;
+      if (!enqueued.has(normalized) && !visited.has(normalized)) {
+        enqueued.add(normalized);
+        queue.push(normalized);
+      }
+    }
+
+    const diagnostics = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      const footer = document.querySelector("footer");
+      const mainTextLength = (main?.textContent ?? "").replace(/\s+/g, " ").trim().length;
+      const viewportHeight = window.innerHeight;
+      const scrollHeight = document.documentElement.scrollHeight;
+
+      let footerTop = null;
+      if (footer) {
+        const rect = footer.getBoundingClientRect();
+        footerTop = rect.top;
+      }
+
+      const emptyContent = !!main && mainTextLength < 100;
+      const weirdFooter =
+        footerTop !== null && scrollHeight <= viewportHeight * 1.05 && footerTop < viewportHeight * 0.75;
+
+      return { emptyContent, weirdFooter };
+    });
+
+    if (diagnostics.emptyContent) notes.push("empty content");
+    if (diagnostics.weirdFooter) notes.push("weird footer position");
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+    notes.push("navigation error");
+  }
+
+  if (status !== 200) {
+    screenshotRelPath = path.join("reports", "screenshots", screenshotNameForUrl(currentUrl));
+    try {
+      await page.screenshot({
+        path: path.resolve(screenshotRelPath),
+        fullPage: true,
+      });
+    } catch {
+      // Ignore screenshot errors so audit can continue.
+    }
+  }
+
+  results.push({
+    url: currentUrl,
+    status,
+    title,
+    notes,
+    error,
+    screenshot: screenshotRelPath,
+  });
+}
+
+await browser.close();
+
+const broken = results.filter((r) => r.status !== 200);
+const topBroken = broken.slice(0, 10);
+const weirdOrEmpty = results.filter((r) => r.notes.includes("empty content") || r.notes.includes("weird footer position"));
+
+const reportLines = [];
+reportLines.push("# Site Audit");
+reportLines.push("");
+reportLines.push(`- Site: ${origin}`);
+reportLines.push(`- Start URL: ${startUrl}`);
+reportLines.push(`- Generated: ${new Date().toISOString()}`);
+reportLines.push(`- Pages visited: ${results.length}`);
+reportLines.push(`- Non-200 pages: ${broken.length}`);
+if (queue.length > 0) {
+  reportLines.push(`- Crawl capped at ${maxPages} pages`);
+}
+reportLines.push("");
+
+reportLines.push("## Top 10 broken links");
+reportLines.push("");
+if (topBroken.length === 0) {
+  reportLines.push("No broken links found.");
+  reportLines.push("");
+} else {
+  reportLines.push("| URL | Status | Title | Screenshot |");
+  reportLines.push("| --- | --- | --- | --- |");
+  for (const row of topBroken) {
+    reportLines.push(
+      `| ${escapeMd(row.url)} | ${escapeMd(String(row.status))} | ${escapeMd(row.title || "-")} | ${row.screenshot ? `[image](${escapeMd(row.screenshot)})` : "-"} |`
+    );
+  }
+  reportLines.push("");
+}
+
+reportLines.push("## Pages with empty content / weird footer");
+reportLines.push("");
+if (weirdOrEmpty.length === 0) {
+  reportLines.push("No pages flagged.");
+  reportLines.push("");
+} else {
+  reportLines.push("| URL | Status | Title | Flags |");
+  reportLines.push("| --- | --- | --- | --- |");
+  for (const row of weirdOrEmpty) {
+    reportLines.push(
+      `| ${escapeMd(row.url)} | ${escapeMd(String(row.status))} | ${escapeMd(row.title || "-")} | ${escapeMd(row.notes.join(", "))} |`
+    );
+  }
+  reportLines.push("");
+}
+
+reportLines.push("## Full crawl results");
+reportLines.push("");
+reportLines.push("| URL | Status | Title | Notes | Error |");
+reportLines.push("| --- | --- | --- | --- | --- |");
+for (const row of results) {
+  reportLines.push(
+    `| ${escapeMd(row.url)} | ${escapeMd(String(row.status))} | ${escapeMd(row.title || "-")} | ${escapeMd(row.notes.join(", ") || "-")} | ${escapeMd(row.error || "-")} |`
+  );
+}
+reportLines.push("");
+
+await fs.writeFile(reportPath, reportLines.join("\n"), "utf8");
+console.log(`Site audit written to ${reportPath}`);
+
+function normalizeUrl(href, base = start.href) {
+  try {
+    const url = new URL(href, base);
+    if (!["http:", "https:"].includes(url.protocol)) return null;
+    if (url.origin !== origin) return null;
+    url.search = "";
+    url.hash = "";
+    if (!url.pathname) url.pathname = "/";
+    if (url.pathname.length > 1) {
+      url.pathname = url.pathname.replace(/\/+$/, "");
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function screenshotNameForUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  const key = `${url.pathname}${url.search || ""}` || "/";
+  const normalized = key
+    .replace(/^\//, "")
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `${normalized || "root"}.png`;
+}
+
+function escapeMd(value) {
+  return value.replace(/\|/g, "\\|").replace(/\n/g, " ");
+}

--- a/src/components/PlaceholderPage.astro
+++ b/src/components/PlaceholderPage.astro
@@ -9,11 +9,31 @@ const { title } = Astro.props;
 ---
 
 <BaseLayout title={title}>
-  <h1>{title}</h1>
-  <p>Phase II rebuild in progress. This page is being updated.</p>
-  <p>
-    <a href="/">Home</a>
-    <span aria-hidden="true"> | </span>
-    <a href="/briefs">Briefs</a>
-  </p>
+  <section class="empty-state">
+    <h1>{title}</h1>
+    <p>Phase II rebuild in progress. This page is being updated.</p>
+    <p class="actions">
+      <a href="/">Home</a>
+      <span aria-hidden="true"> | </span>
+      <a href="/briefs">Briefs</a>
+      <span aria-hidden="true"> | </span>
+      <a href="/marketplace">Marketplace</a>
+    </p>
+  </section>
 </BaseLayout>
+
+<style>
+  .empty-state {
+    border: 1px solid #d8dbe1;
+    background: #fff;
+    padding: 1rem;
+  }
+
+  .empty-state h1 {
+    margin-top: 0;
+  }
+
+  .actions {
+    margin-bottom: 0;
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,7 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
       Trust-first intelligence for regional AI adoption: practical suggestions, dated briefs, and concise reports you can use.
     </p>
     <div class="cta-row">
-      <a class="cta-primary" href="/marketplace">Explore AICV Suggests</a>
+      <a class="cta-primary" href="/marketplace">Explore Marketplace</a>
       <a class="cta-secondary" href="/briefs">Read Briefs</a>
       <a class="cta-tertiary" href="/events">Browse Events</a>
     </div>
@@ -40,9 +40,9 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
     </div>
     <div class="card-grid">
       <article class="card">
-        <h3>Suggests</h3>
+        <h3>Marketplace</h3>
         <p>Curated tools and practical plays for operators in the valley economy.</p>
-        <a href="/marketplace">Explore Suggests</a>
+        <a href="/marketplace">Explore Marketplace</a>
       </article>
       <article class="card">
         <h3>Briefs: Quick</h3>
@@ -94,7 +94,7 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
   </section>
 
   <section>
-    <h2>AICV Suggests</h2>
+    <h2>Marketplace</h2>
     <div class="tile-grid">
       <a class="tile" href="/marketplace">Adoption playbooks</a>
       <a class="tile" href="/cities">City use cases</a>
@@ -143,7 +143,7 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
       <a href="/briefs">Subscribe</a>
       <a href="/contact">Contact</a>
       <a href="/projects">Partners</a>
-      <a href="/contact">Submit a Brief</a>
+      <a href="/submit">Submit a Brief</a>
     </div>
   </section>
 </BaseLayout>


### PR DESCRIPTION
## Summary\n- add Playwright crawler script to audit internal links from SITE_URL\n- record status/title for each crawled page and screenshot non-200 pages\n- write markdown output to reports/site-audit.md with:\n  - Top 10 broken links\n  - Pages with empty content / weird footer\n  - Full crawl results\n- add npm script: 
> technological-transit@0.0.1 audit:site
> node scripts/audit-site.mjs\n- add GitHub Action (manual + push to main) to run audit and upload report artifacts\n\n## Notes\n- Crawl is same-host only\n- Query strings are normalized away to avoid infinite parameter loops\n- Default crawl cap: 500 pages (override with AUDIT_MAX_PAGES)\n\n## Validation\n- SITE_URL=https://www.aicoachellavalley.com AUDIT_MAX_PAGES=200 npm run audit:site\n