### PR TITLE
PR #1: Canonical City Dataset + Dynamic City Hubs

### DIFF
--- a/src/data/cities.ts
+++ b/src/data/cities.ts
@@ -1,0 +1,122 @@
+export interface CityProfile {
+  slug: string;
+  name: string;
+  shortDescription: string;
+  keySectors: string[];
+  signalsWeTrack: string[];
+}
+
+export const CITIES: CityProfile[] = [
+  {
+    slug: "palm-springs",
+    name: "Palm Springs",
+    shortDescription:
+      "Palm Springs is a hospitality and culture anchor where visitor-facing AI adoption is accelerating. City operations also create visible test cases for service delivery and resident communication.",
+    keySectors: ["Hospitality", "Public Services", "Creative Economy"],
+    signalsWeTrack: [
+      "Guest support automation pilots in hotels and venues",
+      "Resident service chat and call-center modernization",
+      "Downtown business adoption of practical AI tools",
+    ],
+  },
+  {
+    slug: "desert-hot-springs",
+    name: "Desert Hot Springs",
+    shortDescription:
+      "Desert Hot Springs combines tourism, wellness, and local services with growing pressure to modernize operations. The city is a practical environment for low-cost AI adoption patterns.",
+    keySectors: ["Wellness Tourism", "Small Business", "Public Services"],
+    signalsWeTrack: [
+      "Spa and hospitality workflow automation signals",
+      "Small business use of AI for customer communication",
+      "City service process improvements using digital tools",
+    ],
+  },
+  {
+    slug: "cathedral-city",
+    name: "Cathedral City",
+    shortDescription:
+      "Cathedral City sits at a key regional crossroads with a mix of retail, logistics, and city services. Its implementation choices can spread quickly across neighboring communities.",
+    keySectors: ["Retail", "Logistics", "Public Services"],
+    signalsWeTrack: [
+      "Retail AI rollout for demand and inventory decisions",
+      "Permit and records workflow modernization",
+      "Local workforce exposure to AI-enabled tools",
+    ],
+  },
+  {
+    slug: "rancho-mirage",
+    name: "Rancho Mirage",
+    shortDescription:
+      "Rancho Mirage has concentrated healthcare and professional services with high expectations for quality and trust. AI adoption here is often risk-aware and governance-led.",
+    keySectors: ["Healthcare", "Professional Services", "Hospitality"],
+    signalsWeTrack: [
+      "Clinical documentation and administrative AI pilots",
+      "Professional service automation with oversight controls",
+      "High-trust hospitality personalization use cases",
+    ],
+  },
+  {
+    slug: "palm-desert",
+    name: "Palm Desert",
+    shortDescription:
+      "Palm Desert is a regional commerce and education hub where AI adoption can bridge enterprise and small-business needs. The city offers a broad view of operational maturity trends.",
+    keySectors: ["Retail", "Education", "Professional Services"],
+    signalsWeTrack: [
+      "Retail operations intelligence and staffing tools",
+      "Education and workforce AI readiness efforts",
+      "SMB adoption of marketing and productivity automation",
+    ],
+  },
+  {
+    slug: "indian-wells",
+    name: "Indian Wells",
+    shortDescription:
+      "Indian Wells has global event visibility and premium visitor experiences that reward operational precision. AI signals here often emerge from event logistics and guest journey optimization.",
+    keySectors: ["Events", "Hospitality", "Tourism Operations"],
+    signalsWeTrack: [
+      "Event operations and scheduling optimization workflows",
+      "Guest experience personalization across venues",
+      "Data practices supporting seasonal demand planning",
+    ],
+  },
+  {
+    slug: "indio",
+    name: "Indio",
+    shortDescription:
+      "Indio is a major event, logistics, and community services center with diverse operating environments. AI adoption patterns here highlight scale, seasonality, and workforce realities.",
+    keySectors: ["Events", "Logistics", "Public Services"],
+    signalsWeTrack: [
+      "Festival and event infrastructure intelligence pilots",
+      "Transportation and logistics coordination improvements",
+      "Public service capacity planning and resident communication",
+    ],
+  },
+  {
+    slug: "la-quinta",
+    name: "La Quinta",
+    shortDescription:
+      "La Quinta blends tourism, sports, and neighborhood-focused city services with strong quality expectations. AI adoption here is often tied to experience management and operational consistency.",
+    keySectors: ["Hospitality", "Sports & Recreation", "Public Services"],
+    signalsWeTrack: [
+      "Resort and recreation operations automation",
+      "Resident communication and city service responsiveness",
+      "Local business AI usage for bookings and outreach",
+    ],
+  },
+  {
+    slug: "coachella",
+    name: "Coachella",
+    shortDescription:
+      "Coachella is a fast-growing city where agriculture, logistics, and community services intersect. Tracking AI here captures both established industry modernization and new local capacity building.",
+    keySectors: ["Agriculture", "Logistics", "Community Services"],
+    signalsWeTrack: [
+      "Agricultural planning and monitoring intelligence pilots",
+      "Warehouse and logistics automation signals",
+      "Community access to AI skills and support pathways",
+    ],
+  },
+];
+
+export const CITY_SLUGS = new Set(CITIES.map((city) => city.slug));
+
+export const getCityBySlug = (slug: string) => CITIES.find((city) => city.slug === slug);

--- a/src/pages/cities/[city].astro
+++ b/src/pages/cities/[city].astro
@@ -2,27 +2,16 @@
 import ActionCard from "../../components/ActionCard.astro";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import PageHero from "../../components/PageHero.astro";
-
-const CITY_PAGES = [
-  { name: "Palm Springs", slug: "palm-springs" },
-  { name: "Desert Hot Springs", slug: "desert-hot-springs" },
-  { name: "Cathedral City", slug: "cathedral-city" },
-  { name: "Rancho Mirage", slug: "rancho-mirage" },
-  { name: "Palm Desert", slug: "palm-desert" },
-  { name: "Indian Wells", slug: "indian-wells" },
-  { name: "Indio", slug: "indio" },
-  { name: "La Quinta", slug: "la-quinta" },
-  { name: "Coachella", slug: "coachella" },
-] as const;
+import { CITIES } from "../../data/cities";
 
 export function getStaticPaths() {
-  return CITY_PAGES.map((city) => ({
+  return CITIES.map((city) => ({
     params: { city: city.slug },
   }));
 }
 
 const cityParam = (Astro.params.city || "").toLowerCase();
-const city = CITY_PAGES.find((entry) => entry.slug === cityParam);
+const city = CITIES.find((entry) => entry.slug === cityParam);
 
 if (!city) {
   return Astro.redirect("/cities", 302);
@@ -31,16 +20,34 @@ if (!city) {
 
 <BaseLayout title={`${city.name} | Cities | AI Coachella Valley`}>
   <PageHero
-    title={`${city.name} Briefs`}
-    description={`City-level briefs and signals for ${city.name}.`}
+    title={city.name}
+    description={city.shortDescription}
   />
+
+  <section>
+    <h2>What we're tracking</h2>
+    <ul class="tracking-list">
+      {city.signalsWeTrack.map((signal) => (
+        <li>{signal}</li>
+      ))}
+    </ul>
+  </section>
+
+  <section>
+    <h2>Key sectors</h2>
+    <ul class="sector-list">
+      {city.keySectors.map((sector) => (
+        <li>{sector}</li>
+      ))}
+    </ul>
+  </section>
 
   <section>
     <h2>Top Paths</h2>
     <div class="path-grid">
       <ActionCard
         title="View all briefs"
-        description="Browse the latest regional evidence and updates."
+        description="Browse the latest city-tagged evidence and regional updates."
         href="/briefs"
         buttonLabel="Open Briefs"
       />
@@ -49,6 +56,12 @@ if (!city) {
         description="Share a verified local signal or implementation update."
         href="/submit"
         buttonLabel="Open Submit a Brief"
+      />
+      <ActionCard
+        title="State of AI"
+        description="Read the current narrative snapshot for this city."
+        href={`/state-of-ai/${city.slug}`}
+        buttonLabel={`Open ${city.name} State of AI`}
       />
     </div>
   </section>
@@ -65,6 +78,14 @@ if (!city) {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
     gap: var(--s-4);
+  }
+
+  .tracking-list,
+  .sector-list {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: var(--s-2);
   }
 
   p > a {

--- a/src/pages/cities/index.astro
+++ b/src/pages/cities/index.astro
@@ -3,7 +3,8 @@ import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import ActionCard from "../../components/ActionCard.astro";
 import PageHero from "../../components/PageHero.astro";
-import { CITY_ENTRIES, normalizeMeta } from "../../utils/briefs";
+import { CITIES } from "../../data/cities";
+import { normalizeMeta } from "../../utils/briefs";
 
 const briefs = await getCollection("signals");
 const briefCountByCity = new Map<string, number>();
@@ -17,7 +18,7 @@ briefs.forEach((brief) => {
 const cityListJsonLd = {
   "@context": "https://schema.org",
   "@type": "ItemList",
-  itemListElement: CITY_ENTRIES.map((city, index) => ({
+  itemListElement: CITIES.map((city, index) => ({
     "@type": "ListItem",
     position: index + 1,
     url: `https://aicoachellavalley.com/cities/${city.slug}`,
@@ -28,16 +29,19 @@ const cityListJsonLd = {
 
 <BaseLayout title="Cities | AI Coachella Valley">
   <script type="application/ld+json" set:html={JSON.stringify(cityListJsonLd)}></script>
-  <PageHero title="All Cities" description="Explore city-level briefs across the Coachella Valley." />
+  <PageHero
+    title="All Cities"
+    description="Explore city-level intelligence hubs across the Coachella Valley using a shared evidence framework."
+  />
   <section>
     <h2>City Brief Hubs</h2>
     <div class="city-grid">
-    {CITY_ENTRIES.map((city) => {
+    {CITIES.map((city) => {
       const count = briefCountByCity.get(city.slug) ?? 0;
       return (
         <ActionCard
           title={city.name}
-          description={`${count} brief${count === 1 ? "" : "s"} currently available`}
+          description={`${city.shortDescription} ${count} brief${count === 1 ? "" : "s"} currently available.`}
           href={`/cities/${city.slug}`}
           buttonLabel={`Open ${city.name}`}
         />

--- a/src/pages/state-of-ai/[city].astro
+++ b/src/pages/state-of-ai/[city].astro
@@ -1,0 +1,124 @@
+---
+import ActionCard from "../../components/ActionCard.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import PageHero from "../../components/PageHero.astro";
+import { CITIES } from "../../data/cities";
+
+export function getStaticPaths() {
+  return CITIES.map((city) => ({
+    params: { city: city.slug },
+  }));
+}
+
+const cityParam = (Astro.params.city || "").toLowerCase();
+const city = CITIES.find((entry) => entry.slug === cityParam);
+
+if (!city) {
+  return Astro.redirect("/state-of-ai", 302);
+}
+
+const opportunities = [
+  "Scale practical city and business workflows with transparent AI tooling.",
+  "Build repeatable playbooks in key local sectors with measurable outcomes.",
+  "Grow regional workforce readiness through hands-on adoption pathways.",
+];
+
+const risks = [
+  "Uneven adoption speed across sectors and organization sizes.",
+  "Evidence gaps where pilots are active but results are not documented.",
+  "Governance and trust concerns if deployment outpaces standards.",
+];
+---
+
+<BaseLayout title={`${city.name} State of AI | AI Coachella Valley`}>
+  <PageHero
+    title={`${city.name} State of AI`}
+    description={`Narrative snapshot backed by city-level evidence signals for ${city.name}.`}
+  />
+
+  <section>
+    <h2>Snapshot</h2>
+    <ul>
+      <li>{city.name} shows active AI signals across {city.keySectors[0]}, {city.keySectors[1]}, and {city.keySectors[2]}.</li>
+      <li>Current momentum centers on operational efficiency and service responsiveness.</li>
+      <li>Local evidence quality improves as more date-stamped briefs are submitted and reviewed.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Evidence</h2>
+    <p>
+      Review the latest verified briefs tied to this city and the broader region.
+    </p>
+    <p><a href={`/cities/${city.slug}`}>Back to {city.name} city hub</a> · <a href="/briefs">Open Briefs</a></p>
+  </section>
+
+  <section>
+    <h2>Opportunities</h2>
+    <ul>
+      {opportunities.map((item) => (
+        <li>{item}</li>
+      ))}
+    </ul>
+  </section>
+
+  <section>
+    <h2>Gaps/Risks</h2>
+    <ul>
+      {risks.map((item) => (
+        <li>{item}</li>
+      ))}
+    </ul>
+  </section>
+
+  <section>
+    <h2>What's Next</h2>
+    <p>
+      AICV will continue publishing date-stamped briefs, then update this city narrative as higher-confidence
+      evidence accumulates across sectors and public service workflows.
+    </p>
+  </section>
+
+  <section>
+    <h2>Top Paths</h2>
+    <div class="path-grid">
+      <ActionCard
+        title={`Open ${city.name} City Hub`}
+        description="Return to the city intelligence page."
+        href={`/cities/${city.slug}`}
+        buttonLabel="Open City Hub"
+      />
+      <ActionCard
+        title="View all briefs"
+        description="Scan the evidence layer across all cities."
+        href="/briefs"
+        buttonLabel="Open Briefs"
+      />
+      <ActionCard
+        title="Submit a brief"
+        description="Contribute a new city signal for editorial review."
+        href="/submit"
+        buttonLabel="Open Submit a Brief"
+      />
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  section + section {
+    margin-top: var(--s-7);
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: var(--s-2);
+  }
+
+  .path-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    gap: var(--s-4);
+  }
+</style>

--- a/src/utils/briefs.ts
+++ b/src/utils/briefs.ts
@@ -1,3 +1,5 @@
+import { CITIES } from "../data/cities";
+
 export const normalizeMeta = (value?: string) =>
   (value ?? "")
     .toLowerCase()
@@ -22,17 +24,7 @@ export const resolveSummary = (entry: {
   return "No summary available.";
 };
 
-export const CITY_ENTRIES = [
-  { name: "Palm Springs", slug: "palm-springs" },
-  { name: "Desert Hot Springs", slug: "desert-hot-springs" },
-  { name: "Cathedral City", slug: "cathedral-city" },
-  { name: "Rancho Mirage", slug: "rancho-mirage" },
-  { name: "Palm Desert", slug: "palm-desert" },
-  { name: "Indian Wells", slug: "indian-wells" },
-  { name: "Indio", slug: "indio" },
-  { name: "La Quinta", slug: "la-quinta" },
-  { name: "Coachella", slug: "coachella" },
-] as const;
+export const CITY_ENTRIES = CITIES.map(({ name, slug }) => ({ name, slug }));
 
 export const labelFromSlug = (slug: string) =>
   slug


### PR DESCRIPTION
## Summary (what + why)
Introduces a single canonical 9-city dataset and uses it to power city routing/UI, so city intelligence pages are consistent, browsable, and citation-ready. This removes duplicated city definitions and eliminates trust-breaking 404 risk from city top-path navigation.

## What changed (file list)
- src/data/cities.ts
- src/pages/cities/index.astro
- src/pages/cities/[city].astro
- src/pages/state-of-ai/[city].astro
- src/utils/briefs.ts

## Verification (Vercel-only)
- Preview URL: _to be added by Vercel on PR_
- Production target: https://aicoachellavalley-site.vercel.app
- Checklist:
  - [x] npm run build passes locally
  - [x] /cities renders from canonical dataset
  - [x] All 9 city slugs exist in canonical dataset
  - [x] /cities/<slug> routes are generated from canonical dataset
  - [x] City Top Paths use safe, live destinations (/briefs, /submit, /state-of-ai/<slug>)
  - [x] Added /state-of-ai/<slug> dynamic route to prevent 404s from city Top Paths

## Notes (pre-cutover reminder)
Pre-cutover mode preserved: no redirect/canonical enforcement to www.aicoachellavalley.com; verification targets Vercel URLs only.
