### PR TITLE
PR #2: State of AI Index + Evidence-First City Scaffolds

### DIFF
--- a/src/components/ResearchCoverage.astro
+++ b/src/components/ResearchCoverage.astro
@@ -1,0 +1,69 @@
+---
+interface CoverageMetrics {
+  meetingsScanned: number | null;
+  transcriptsAvailable: number | null;
+  documentsScanned: number | null;
+  aiMentionsFound: number | null;
+  lastScanDate: string | null;
+}
+
+interface Props {
+  coverage?: CoverageMetrics;
+}
+
+const { coverage } = Astro.props as Props;
+
+const numberDisplay = (value: number | null | undefined) => (typeof value === "number" ? String(value) : "—");
+const dateDisplay = (value: string | null | undefined) => (value && value.trim().length > 0 ? value : "In progress");
+---
+
+<div class="coverage-grid">
+  <article class="coverage-item">
+    <h3>Meetings scanned</h3>
+    <p>{numberDisplay(coverage?.meetingsScanned)}</p>
+  </article>
+  <article class="coverage-item">
+    <h3>Transcripts available</h3>
+    <p>{numberDisplay(coverage?.transcriptsAvailable)}</p>
+  </article>
+  <article class="coverage-item">
+    <h3>Documents scanned</h3>
+    <p>{numberDisplay(coverage?.documentsScanned)}</p>
+  </article>
+  <article class="coverage-item">
+    <h3>AI mentions found</h3>
+    <p>{numberDisplay(coverage?.aiMentionsFound)}</p>
+  </article>
+  <article class="coverage-item">
+    <h3>Last scan date</h3>
+    <p>{dateDisplay(coverage?.lastScanDate)}</p>
+  </article>
+</div>
+
+<style>
+  .coverage-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+    gap: var(--s-3);
+  }
+
+  .coverage-item {
+    border: 1px solid var(--c-border);
+    border-radius: var(--r-md);
+    background: var(--c-surface);
+    box-shadow: var(--shadow-1);
+    padding: var(--s-4);
+  }
+
+  .coverage-item h3 {
+    margin: 0;
+    font-size: 0.98rem;
+  }
+
+  .coverage-item p {
+    margin: var(--s-2) 0 0;
+    color: var(--c-muted);
+    font-size: 1rem;
+    font-weight: 600;
+  }
+</style>

--- a/src/data/cities.ts
+++ b/src/data/cities.ts
@@ -4,6 +4,17 @@ export interface CityProfile {
   shortDescription: string;
   keySectors: string[];
   signalsWeTrack: string[];
+  stateOfAI?: {
+    lastUpdated?: string;
+    status: "baseline" | "in-progress" | "published";
+    coverage: {
+      meetingsScanned: number | null;
+      transcriptsAvailable: number | null;
+      documentsScanned: number | null;
+      aiMentionsFound: number | null;
+      lastScanDate: string | null;
+    };
+  };
 }
 
 export const CITIES: CityProfile[] = [
@@ -18,6 +29,16 @@ export const CITIES: CityProfile[] = [
       "Resident service chat and call-center modernization",
       "Downtown business adoption of practical AI tools",
     ],
+    stateOfAI: {
+      status: "baseline",
+      coverage: {
+        meetingsScanned: null,
+        transcriptsAvailable: null,
+        documentsScanned: null,
+        aiMentionsFound: null,
+        lastScanDate: null,
+      },
+    },
   },
   {
     slug: "desert-hot-springs",
@@ -30,6 +51,16 @@ export const CITIES: CityProfile[] = [
       "Small business use of AI for customer communication",
       "City service process improvements using digital tools",
     ],
+    stateOfAI: {
+      status: "baseline",
+      coverage: {
+        meetingsScanned: null,
+        transcriptsAvailable: null,
+        documentsScanned: null,
+        aiMentionsFound: null,
+        lastScanDate: null,
+      },
+    },
   },
   {
     slug: "cathedral-city",
@@ -42,6 +73,16 @@ export const CITIES: CityProfile[] = [
       "Permit and records workflow modernization",
       "Local workforce exposure to AI-enabled tools",
     ],
+    stateOfAI: {
+      status: "baseline",
+      coverage: {
+        meetingsScanned: null,
+        transcriptsAvailable: null,
+        documentsScanned: null,
+        aiMentionsFound: null,
+        lastScanDate: null,
+      },
+    },
   },
   {
     slug: "rancho-mirage",
@@ -54,6 +95,16 @@ export const CITIES: CityProfile[] = [
       "Professional service automation with oversight controls",
       "High-trust hospitality personalization use cases",
     ],
+    stateOfAI: {
+      status: "baseline",
+      coverage: {
+        meetingsScanned: null,
+        transcriptsAvailable: null,
+        documentsScanned: null,
+        aiMentionsFound: null,
+        lastScanDate: null,
+      },
+    },
   },
   {
     slug: "palm-desert",
@@ -66,6 +117,16 @@ export const CITIES: CityProfile[] = [
       "Education and workforce AI readiness efforts",
       "SMB adoption of marketing and productivity automation",
     ],
+    stateOfAI: {
+      status: "baseline",
+      coverage: {
+        meetingsScanned: null,
+        transcriptsAvailable: null,
+        documentsScanned: null,
+        aiMentionsFound: null,
+        lastScanDate: null,
+      },
+    },
   },
   {
     slug: "indian-wells",
@@ -78,6 +139,16 @@ export const CITIES: CityProfile[] = [
       "Guest experience personalization across venues",
       "Data practices supporting seasonal demand planning",
     ],
+    stateOfAI: {
+      status: "baseline",
+      coverage: {
+        meetingsScanned: null,
+        transcriptsAvailable: null,
+        documentsScanned: null,
+        aiMentionsFound: null,
+        lastScanDate: null,
+      },
+    },
   },
   {
     slug: "indio",
@@ -90,6 +161,16 @@ export const CITIES: CityProfile[] = [
       "Transportation and logistics coordination improvements",
       "Public service capacity planning and resident communication",
     ],
+    stateOfAI: {
+      status: "baseline",
+      coverage: {
+        meetingsScanned: null,
+        transcriptsAvailable: null,
+        documentsScanned: null,
+        aiMentionsFound: null,
+        lastScanDate: null,
+      },
+    },
   },
   {
     slug: "la-quinta",
@@ -102,6 +183,16 @@ export const CITIES: CityProfile[] = [
       "Resident communication and city service responsiveness",
       "Local business AI usage for bookings and outreach",
     ],
+    stateOfAI: {
+      status: "baseline",
+      coverage: {
+        meetingsScanned: null,
+        transcriptsAvailable: null,
+        documentsScanned: null,
+        aiMentionsFound: null,
+        lastScanDate: null,
+      },
+    },
   },
   {
     slug: "coachella",
@@ -114,6 +205,16 @@ export const CITIES: CityProfile[] = [
       "Warehouse and logistics automation signals",
       "Community access to AI skills and support pathways",
     ],
+    stateOfAI: {
+      status: "baseline",
+      coverage: {
+        meetingsScanned: null,
+        transcriptsAvailable: null,
+        documentsScanned: null,
+        aiMentionsFound: null,
+        lastScanDate: null,
+      },
+    },
   },
 ];
 

--- a/src/pages/state-of-ai/[city].astro
+++ b/src/pages/state-of-ai/[city].astro
@@ -2,7 +2,10 @@
 import ActionCard from "../../components/ActionCard.astro";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import PageHero from "../../components/PageHero.astro";
+import ResearchCoverage from "../../components/ResearchCoverage.astro";
 import { CITIES } from "../../data/cities";
+import { getCollection } from "astro:content";
+import { normalizeMeta, resolveSummary } from "../../utils/briefs";
 
 export function getStaticPaths() {
   return CITIES.map((city) => ({
@@ -14,76 +17,89 @@ const cityParam = (Astro.params.city || "").toLowerCase();
 const city = CITIES.find((entry) => entry.slug === cityParam);
 
 if (!city) {
-  return Astro.redirect("/state-of-ai", 302);
+  return new Response(null, { status: 404, statusText: "Not Found" });
 }
 
-const opportunities = [
-  "Scale practical city and business workflows with transparent AI tooling.",
-  "Build repeatable playbooks in key local sectors with measurable outcomes.",
-  "Grow regional workforce readiness through hands-on adoption pathways.",
-];
+const allBriefs = await getCollection("signals");
+const confirmedBriefs = allBriefs
+  .filter((brief) => normalizeMeta(brief.data.city) === city.slug)
+  .filter((brief) => Array.isArray(brief.data.sources) && brief.data.sources.length > 0)
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 
-const risks = [
-  "Uneven adoption speed across sectors and organization sizes.",
-  "Evidence gaps where pilots are active but results are not documented.",
-  "Governance and trust concerns if deployment outpaces standards.",
+const lastUpdated = city.stateOfAI?.lastUpdated || new Date().toISOString().slice(0, 10);
+const watchCategories = [
+  "Procurement",
+  "Workforce",
+  "Education",
+  "Public Safety",
+  "Privacy",
+  "Economic Development",
 ];
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "short",
+  day: "2-digit",
+});
 ---
 
 <BaseLayout title={`${city.name} State of AI | AI Coachella Valley`}>
   <PageHero
-    title={`${city.name} State of AI`}
-    description={`Narrative snapshot backed by city-level evidence signals for ${city.name}.`}
+    title={`State of AI in ${city.name}`}
+    description="Baseline snapshot (public-source evidence)."
   />
 
   <section>
-    <h2>Snapshot</h2>
-    <ul>
-      <li>{city.name} shows active AI signals across {city.keySectors[0]}, {city.keySectors[1]}, and {city.keySectors[2]}.</li>
-      <li>Current momentum centers on operational efficiency and service responsiveness.</li>
-      <li>Local evidence quality improves as more date-stamped briefs are submitted and reviewed.</li>
-    </ul>
+    <p class="meta-line"><strong>Last updated:</strong> {lastUpdated}</p>
   </section>
 
   <section>
-    <h2>Evidence</h2>
-    <p>
-      Review the latest verified briefs tied to this city and the broader region.
-    </p>
-    <p><a href={`/cities/${city.slug}`}>Back to {city.name} city hub</a> · <a href="/briefs">Open Briefs</a></p>
+    <h2>Confirmed signals</h2>
+    {confirmedBriefs.length === 0 ? (
+      <>
+        <p>
+          No confirmed public AI references yet. This page will update as sources are scanned and briefs are submitted.
+        </p>
+        <p><a class="btn btn-secondary" href="/submit">Submit a brief</a></p>
+      </>
+    ) : (
+      <div class="signals-grid">
+        {confirmedBriefs.map((brief) => (
+          <article class="signal-card">
+            <h3><a href={`/briefs/${brief.slug}`}>{brief.data.title}</a></h3>
+            <p class="signal-meta">{dateFormatter.format(brief.data.date)}</p>
+            <p>{resolveSummary(brief)}</p>
+            <h4>Sources</h4>
+            <ul class="source-list">
+              {(brief.data.sources || []).map((url) => (
+                <li><a href={url} target="_blank" rel="noreferrer">{url}</a></li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    )}
   </section>
 
   <section>
-    <h2>Opportunities</h2>
+    <h2>Research Coverage</h2>
+    <ResearchCoverage coverage={city.stateOfAI?.coverage} />
+  </section>
+
+  <section>
+    <h2>What we're watching</h2>
+    <p>These are the public-source categories we track for city AI signal.</p>
     <ul>
-      {opportunities.map((item) => (
+      {watchCategories.map((item) => (
         <li>{item}</li>
       ))}
     </ul>
-  </section>
-
-  <section>
-    <h2>Gaps/Risks</h2>
-    <ul>
-      {risks.map((item) => (
-        <li>{item}</li>
-      ))}
-    </ul>
-  </section>
-
-  <section>
-    <h2>What's Next</h2>
-    <p>
-      AICV will continue publishing date-stamped briefs, then update this city narrative as higher-confidence
-      evidence accumulates across sectors and public service workflows.
-    </p>
   </section>
 
   <section>
     <h2>Top Paths</h2>
     <div class="path-grid">
       <ActionCard
-        title={`Open ${city.name} City Hub`}
+        title={`Open ${city.name} city hub`}
         description="Return to the city intelligence page."
         href={`/cities/${city.slug}`}
         buttonLabel="Open City Hub"
@@ -96,7 +112,7 @@ const risks = [
       />
       <ActionCard
         title="Submit a brief"
-        description="Contribute a new city signal for editorial review."
+        description="Contribute source-backed evidence for this city."
         href="/submit"
         buttonLabel="Open Submit a Brief"
       />
@@ -116,9 +132,42 @@ const risks = [
     gap: var(--s-2);
   }
 
+  .meta-line {
+    margin: 0;
+    color: var(--c-muted);
+  }
+
+  .signals-grid,
   .path-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
     gap: var(--s-4);
+  }
+
+  .signal-card {
+    border: 1px solid var(--c-border);
+    border-radius: var(--r-md);
+    background: var(--c-surface);
+    box-shadow: var(--shadow-1);
+    padding: var(--s-5);
+  }
+
+  .signal-card h3 {
+    margin: 0;
+  }
+
+  .signal-card h4 {
+    margin-bottom: 0.45rem;
+    font-size: 0.95rem;
+  }
+
+  .signal-meta {
+    color: var(--c-muted);
+    margin-bottom: var(--s-2);
+  }
+
+  .source-list {
+    margin: 0;
+    padding-left: 1.2rem;
   }
 </style>

--- a/src/pages/state-of-ai/index.astro
+++ b/src/pages/state-of-ai/index.astro
@@ -2,35 +2,34 @@
 import ActionCard from "../../components/ActionCard.astro";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import PageHero from "../../components/PageHero.astro";
+import { CITIES } from "../../data/cities";
 ---
 
 <BaseLayout title="State of AI | AI Coachella Valley">
   <PageHero
     title="State of AI"
-    description="A high-level view of regional momentum, practical standards, and operating signals across sectors."
+    description="Evidence-first city snapshots of practical AI adoption across the Coachella Valley."
   />
 
   <section>
-    <h2>Top Paths</h2>
+    <h2>Method</h2>
+    <p>
+      Each city page is grounded in published briefs and public-source evidence only. No URL = no claim. As
+      new source-backed briefs are added, snapshots and coverage metrics update.
+    </p>
+  </section>
+
+  <section>
+    <h2>City State of AI Pages</h2>
     <div class="path-grid">
-      <ActionCard
-        title="Latest Briefs"
-        description="Review current evidence before adopting new AI priorities."
-        href="/briefs"
-        buttonLabel="Open Latest Briefs"
-      />
-      <ActionCard
-        title="Cities"
-        description="Track implementation signals by city and local operating context."
-        href="/cities"
-        buttonLabel="Open Cities"
-      />
-      <ActionCard
-        title="Submit a Brief"
-        description="Contribute a new signal to strengthen the regional evidence base."
-        href="/submit"
-        buttonLabel="Open Submit a Brief"
-      />
+      {CITIES.map((city) => (
+        <ActionCard
+          title={city.name}
+          description={city.shortDescription}
+          href={`/state-of-ai/${city.slug}`}
+          buttonLabel={`Open ${city.name}`}
+        />
+      ))}
     </div>
   </section>
 </BaseLayout>


### PR DESCRIPTION
## Summary (what + why)
Builds a canonical State of AI system from the shared 9-city dataset. The index now routes to all city pages, and each city page is an evidence-first scaffold that only surfaces source-backed briefs (no source, no claim) while still rendering useful coverage placeholders before deeper ingestion lands.

## What changed (file list)
- src/pages/state-of-ai/index.astro
- src/pages/state-of-ai/[city].astro
- src/components/ResearchCoverage.astro
- src/data/cities.ts

## Verification (Vercel-only)
- Preview URL: _to be added by Vercel on PR_
- Production target: https://aicoachellavalley-site.vercel.app
- Checklist:
  - [x] npm run build passes locally
  - [x] /state-of-ai renders all 9 cities from cities.ts
  - [x] /state-of-ai/<slug> resolves for canonical city slugs
  - [x] Unknown city slug returns 404
  - [x] Confirmed signals only include briefs with sources
  - [x] Empty-state copy + /submit CTA render when no sourced briefs exist
  - [x] Research Coverage renders null-safe placeholders (no fabricated 0 values)
  - [x] All CTAs on State of AI pages resolve to live routes

## Notes (pre-cutover reminder)
Pre-cutover mode preserved: no forced redirect/canonical behavior to www.aicoachellavalley.com; verification targets Vercel URLs only.
