### PR TITLE
PR #6: Enrich baseline briefs with multi-source official entrypoints

### DIFF
--- a/src/content/signals/2025-12-01-palm-springs-ai-signal-scan-baseline.md
+++ b/src/content/signals/2025-12-01-palm-springs-ai-signal-scan-baseline.md
@@ -6,7 +6,9 @@ sector: Public Sector
 signal_type: research
 confidence: low
 sources:
+  - https://www.palmspringsca.gov/government/city-council/city-council-meetings
   - https://www.palmspringsca.gov/government/city-clerk
+  - https://www.youtube.com/@CityofPalmSprings
 summary: "Baseline stub for Palm Springs source tracking. Evidence briefs will be added as official materials are scanned and validated."
 ---
 
@@ -15,7 +17,7 @@ summary: "Baseline stub for Palm Springs source tracking. Evidence briefs will b
 ## Scope
 Baseline stub. Evidence briefs will be added as sources are scanned and validated.
 
-This entry does not assert that AI was discussed in the linked material. It records an official source endpoint for ongoing review.
+This entry does not assert that AI was discussed in the linked material. It records official source entrypoints for ongoing review.
 
 ## What we will track
 - procurement
@@ -26,7 +28,11 @@ This entry does not assert that AI was discussed in the linked material. It reco
 - economic development
 
 ## Sources
-- https://www.palmspringsca.gov/government/city-clerk
+| Label | Type | URL | Notes |
+| --- | --- | --- | --- |
+| City Council Meetings | Agendas-Minutes | https://www.palmspringsca.gov/government/city-council/city-council-meetings | Primary archive for city council packets and meeting records. |
+| City Clerk | Docs | https://www.palmspringsca.gov/government/city-clerk | Official records hub used to locate agendas, minutes, and notices. |
+| City of Palm Springs YouTube | YouTube | https://www.youtube.com/@CityofPalmSprings | Official city video channel for meeting and public session recordings. |
 
 ## Related nodes
 - City hub: /cities/palm-springs

--- a/src/content/signals/2025-12-02-desert-hot-springs-ai-signal-scan-baseline.md
+++ b/src/content/signals/2025-12-02-desert-hot-springs-ai-signal-scan-baseline.md
@@ -7,6 +7,8 @@ signal_type: research
 confidence: low
 sources:
   - https://www.cityofdhs.org/city-council-agendas/
+  - https://www.cityofdhs.org/department/city-clerk/
+  - https://www.youtube.com/@cityofdeserthotsprings
 summary: "Baseline stub for Desert Hot Springs source tracking. Evidence briefs will be added as official materials are scanned and validated."
 ---
 
@@ -15,7 +17,7 @@ summary: "Baseline stub for Desert Hot Springs source tracking. Evidence briefs 
 ## Scope
 Baseline stub. Evidence briefs will be added as sources are scanned and validated.
 
-This entry does not assert that AI was discussed in the linked material. It records an official source endpoint for ongoing review.
+This entry does not assert that AI was discussed in the linked material. It records official source entrypoints for ongoing review.
 
 ## What we will track
 - procurement
@@ -26,7 +28,11 @@ This entry does not assert that AI was discussed in the linked material. It reco
 - economic development
 
 ## Sources
-- https://www.cityofdhs.org/city-council-agendas/
+| Label | Type | URL | Notes |
+| --- | --- | --- | --- |
+| City Council Agendas | Agendas-Minutes | https://www.cityofdhs.org/city-council-agendas/ | Primary archive for posted agendas and council meeting materials. |
+| City Clerk | Docs | https://www.cityofdhs.org/department/city-clerk/ | Official records page for notices, agendas, and filing references. |
+| City of Desert Hot Springs YouTube | YouTube | https://www.youtube.com/@cityofdeserthotsprings | Official city video channel for public meetings and updates. |
 
 ## Related nodes
 - City hub: /cities/desert-hot-springs

--- a/src/content/signals/2025-12-03-cathedral-city-ai-signal-scan-baseline.md
+++ b/src/content/signals/2025-12-03-cathedral-city-ai-signal-scan-baseline.md
@@ -7,6 +7,8 @@ signal_type: research
 confidence: low
 sources:
   - https://www.cathedralcity.gov/government/agendas-minutes/agendas-and-minutes
+  - https://www.cathedralcity.gov/government/city-council/city-council-meetings
+  - https://www.youtube.com/@CathedralCityGov
 summary: "Baseline stub for Cathedral City source tracking. Evidence briefs will be added as official materials are scanned and validated."
 ---
 
@@ -15,7 +17,7 @@ summary: "Baseline stub for Cathedral City source tracking. Evidence briefs will
 ## Scope
 Baseline stub. Evidence briefs will be added as sources are scanned and validated.
 
-This entry does not assert that AI was discussed in the linked material. It records an official source endpoint for ongoing review.
+This entry does not assert that AI was discussed in the linked material. It records official source entrypoints for ongoing review.
 
 ## What we will track
 - procurement
@@ -26,7 +28,11 @@ This entry does not assert that AI was discussed in the linked material. It reco
 - economic development
 
 ## Sources
-- https://www.cathedralcity.gov/government/agendas-minutes/agendas-and-minutes
+| Label | Type | URL | Notes |
+| --- | --- | --- | --- |
+| Agendas and Minutes | Agendas-Minutes | https://www.cathedralcity.gov/government/agendas-minutes/agendas-and-minutes | Primary archive for council agendas and approved minutes. |
+| City Council Meetings | Docs | https://www.cathedralcity.gov/government/city-council/city-council-meetings | Official council page used for meeting schedules and records. |
+| Cathedral City Government YouTube | YouTube | https://www.youtube.com/@CathedralCityGov | Official city video channel for council and commission recordings. |
 
 ## Related nodes
 - City hub: /cities/cathedral-city

--- a/src/content/signals/2025-12-04-rancho-mirage-ai-signal-scan-baseline.md
+++ b/src/content/signals/2025-12-04-rancho-mirage-ai-signal-scan-baseline.md
@@ -6,6 +6,8 @@ sector: Public Sector
 signal_type: research
 confidence: low
 sources:
+  - https://www.ranchomirageca.gov/government/city-council
+  - https://www.ranchomirageca.gov/government/city-clerk/agendas-minutes
   - https://www.youtube.com/@cityofranchomirageca
 summary: "Baseline stub for Rancho Mirage source tracking. Evidence briefs will be added as official materials are scanned and validated."
 ---
@@ -15,7 +17,7 @@ summary: "Baseline stub for Rancho Mirage source tracking. Evidence briefs will 
 ## Scope
 Baseline stub. Evidence briefs will be added as sources are scanned and validated.
 
-This entry does not assert that AI was discussed in the linked material. It records an official source endpoint for ongoing review.
+This entry does not assert that AI was discussed in the linked material. It records official source entrypoints for ongoing review.
 
 ## What we will track
 - procurement
@@ -26,7 +28,11 @@ This entry does not assert that AI was discussed in the linked material. It reco
 - economic development
 
 ## Sources
-- https://www.youtube.com/@cityofranchomirageca
+| Label | Type | URL | Notes |
+| --- | --- | --- | --- |
+| City Council | Agendas-Minutes | https://www.ranchomirageca.gov/government/city-council | Official council page used for meetings, agenda packets, and links. |
+| City Clerk Agendas and Minutes | Docs | https://www.ranchomirageca.gov/government/city-clerk/agendas-minutes | Primary records archive for council and commission documents. |
+| City of Rancho Mirage YouTube | YouTube | https://www.youtube.com/@cityofranchomirageca | Official city video channel for meeting recordings and updates. |
 
 ## Related nodes
 - City hub: /cities/rancho-mirage

--- a/src/content/signals/2025-12-05-palm-desert-ai-signal-scan-baseline.md
+++ b/src/content/signals/2025-12-05-palm-desert-ai-signal-scan-baseline.md
@@ -6,7 +6,9 @@ sector: Public Sector
 signal_type: research
 confidence: low
 sources:
-  - https://www.palmdesert.gov/
+  - https://www.palmdesert.gov/government/city-council/city-council-meetings
+  - https://www.palmdesert.gov/government/city-clerk/agendas-minutes
+  - https://www.youtube.com/@CityofPalmDesert
 summary: "Baseline stub for Palm Desert source tracking. Evidence briefs will be added as official materials are scanned and validated."
 ---
 
@@ -15,7 +17,7 @@ summary: "Baseline stub for Palm Desert source tracking. Evidence briefs will be
 ## Scope
 Baseline stub. Evidence briefs will be added as sources are scanned and validated.
 
-This entry does not assert that AI was discussed in the linked material. It records an official source endpoint for ongoing review.
+This entry does not assert that AI was discussed in the linked material. It records official source entrypoints for ongoing review.
 
 ## What we will track
 - procurement
@@ -26,7 +28,11 @@ This entry does not assert that AI was discussed in the linked material. It reco
 - economic development
 
 ## Sources
-- https://www.palmdesert.gov/
+| Label | Type | URL | Notes |
+| --- | --- | --- | --- |
+| City Council Meetings | Agendas-Minutes | https://www.palmdesert.gov/government/city-council/city-council-meetings | Primary council meetings page for schedules and agenda links. |
+| City Clerk Agendas and Minutes | Docs | https://www.palmdesert.gov/government/city-clerk/agendas-minutes | Official records archive for meeting documents and minutes. |
+| City of Palm Desert YouTube | YouTube | https://www.youtube.com/@CityofPalmDesert | Official city video channel used for meeting and workshop recordings. |
 
 ## Related nodes
 - City hub: /cities/palm-desert

--- a/src/content/signals/2025-12-06-indian-wells-ai-signal-scan-baseline.md
+++ b/src/content/signals/2025-12-06-indian-wells-ai-signal-scan-baseline.md
@@ -7,6 +7,8 @@ signal_type: research
 confidence: low
 sources:
   - https://www.cityofindianwells.org/i-want-to/view/view-city-council-meetings/city-council-meetings
+  - https://www.cityofindianwells.org/government/city-clerk
+  - https://www.youtube.com/@CityofIndianWells
 summary: "Baseline stub for Indian Wells source tracking. Evidence briefs will be added as official materials are scanned and validated."
 ---
 
@@ -15,7 +17,7 @@ summary: "Baseline stub for Indian Wells source tracking. Evidence briefs will b
 ## Scope
 Baseline stub. Evidence briefs will be added as sources are scanned and validated.
 
-This entry does not assert that AI was discussed in the linked material. It records an official source endpoint for ongoing review.
+This entry does not assert that AI was discussed in the linked material. It records official source entrypoints for ongoing review.
 
 ## What we will track
 - procurement
@@ -26,7 +28,11 @@ This entry does not assert that AI was discussed in the linked material. It reco
 - economic development
 
 ## Sources
-- https://www.cityofindianwells.org/i-want-to/view/view-city-council-meetings/city-council-meetings
+| Label | Type | URL | Notes |
+| --- | --- | --- | --- |
+| City Council Meetings | Agendas-Minutes | https://www.cityofindianwells.org/i-want-to/view/view-city-council-meetings/city-council-meetings | Primary council meetings entrypoint for packets and recordings. |
+| City Clerk | Docs | https://www.cityofindianwells.org/government/city-clerk | Official records hub for notices, minutes, and document links. |
+| City of Indian Wells YouTube | YouTube | https://www.youtube.com/@CityofIndianWells | Official city video channel used for public meeting archives. |
 
 ## Related nodes
 - City hub: /cities/indian-wells

--- a/src/content/signals/2025-12-07-indio-ai-signal-scan-baseline.md
+++ b/src/content/signals/2025-12-07-indio-ai-signal-scan-baseline.md
@@ -7,6 +7,8 @@ signal_type: research
 confidence: low
 sources:
   - https://www.indio.org/departments/city-clerk/agendas-minutes-videos
+  - https://www.indio.org/government/city-council
+  - https://www.youtube.com/@CityofIndio
 summary: "Baseline stub for Indio source tracking. Evidence briefs will be added as official materials are scanned and validated."
 ---
 
@@ -15,7 +17,7 @@ summary: "Baseline stub for Indio source tracking. Evidence briefs will be added
 ## Scope
 Baseline stub. Evidence briefs will be added as sources are scanned and validated.
 
-This entry does not assert that AI was discussed in the linked material. It records an official source endpoint for ongoing review.
+This entry does not assert that AI was discussed in the linked material. It records official source entrypoints for ongoing review.
 
 ## What we will track
 - procurement
@@ -26,7 +28,11 @@ This entry does not assert that AI was discussed in the linked material. It reco
 - economic development
 
 ## Sources
-- https://www.indio.org/departments/city-clerk/agendas-minutes-videos
+| Label | Type | URL | Notes |
+| --- | --- | --- | --- |
+| Agendas, Minutes, and Videos | Agendas-Minutes | https://www.indio.org/departments/city-clerk/agendas-minutes-videos | Primary archive for council documents and linked videos. |
+| City Council | Docs | https://www.indio.org/government/city-council | Official council page for schedules, agenda packets, and references. |
+| City of Indio YouTube | YouTube | https://www.youtube.com/@CityofIndio | Official city video channel for council and commission sessions. |
 
 ## Related nodes
 - City hub: /cities/indio

--- a/src/content/signals/2025-12-08-la-quinta-ai-signal-scan-baseline.md
+++ b/src/content/signals/2025-12-08-la-quinta-ai-signal-scan-baseline.md
@@ -7,6 +7,8 @@ signal_type: research
 confidence: low
 sources:
   - https://www.laquintaca.gov/business/city-council/city-council-agendas
+  - https://www.laquintaca.gov/business/city-council/city-council-videos
+  - https://www.youtube.com/@cityoflaquinta
 summary: "Baseline stub for La Quinta source tracking. Evidence briefs will be added as official materials are scanned and validated."
 ---
 
@@ -15,7 +17,7 @@ summary: "Baseline stub for La Quinta source tracking. Evidence briefs will be a
 ## Scope
 Baseline stub. Evidence briefs will be added as sources are scanned and validated.
 
-This entry does not assert that AI was discussed in the linked material. It records an official source endpoint for ongoing review.
+This entry does not assert that AI was discussed in the linked material. It records official source entrypoints for ongoing review.
 
 ## What we will track
 - procurement
@@ -26,7 +28,11 @@ This entry does not assert that AI was discussed in the linked material. It reco
 - economic development
 
 ## Sources
-- https://www.laquintaca.gov/business/city-council/city-council-agendas
+| Label | Type | URL | Notes |
+| --- | --- | --- | --- |
+| City Council Agendas | Agendas-Minutes | https://www.laquintaca.gov/business/city-council/city-council-agendas | Primary archive for posted agendas and agenda packets. |
+| City Council Videos | Video Archive | https://www.laquintaca.gov/business/city-council/city-council-videos | Official meeting video archive used for session review. |
+| City of La Quinta YouTube | YouTube | https://www.youtube.com/@cityoflaquinta | Official city video channel for public meetings and updates. |
 
 ## Related nodes
 - City hub: /cities/la-quinta

--- a/src/content/signals/2025-12-09-coachella-ai-signal-scan-baseline.md
+++ b/src/content/signals/2025-12-09-coachella-ai-signal-scan-baseline.md
@@ -7,6 +7,8 @@ signal_type: research
 confidence: low
 sources:
   - https://www.coachella.org/city-government/city-council/agendas-and-minutes
+  - https://www.coachella.org/city-government/city-council/city-council-videos
+  - https://www.youtube.com/@cityofcoachella
 summary: "Baseline stub for Coachella source tracking. Evidence briefs will be added as official materials are scanned and validated."
 ---
 
@@ -15,7 +17,7 @@ summary: "Baseline stub for Coachella source tracking. Evidence briefs will be a
 ## Scope
 Baseline stub. Evidence briefs will be added as sources are scanned and validated.
 
-This entry does not assert that AI was discussed in the linked material. It records an official source endpoint for ongoing review.
+This entry does not assert that AI was discussed in the linked material. It records official source entrypoints for ongoing review.
 
 ## What we will track
 - procurement
@@ -26,7 +28,11 @@ This entry does not assert that AI was discussed in the linked material. It reco
 - economic development
 
 ## Sources
-- https://www.coachella.org/city-government/city-council/agendas-and-minutes
+| Label | Type | URL | Notes |
+| --- | --- | --- | --- |
+| Agendas and Minutes | Agendas-Minutes | https://www.coachella.org/city-government/city-council/agendas-and-minutes | Primary archive for council agendas, packets, and minutes. |
+| City Council Videos | Video Archive | https://www.coachella.org/city-government/city-council/city-council-videos | Official meeting video archive for council session review. |
+| City of Coachella YouTube | YouTube | https://www.youtube.com/@cityofcoachella | Official city video channel for public meeting recordings. |
 
 ## Related nodes
 - City hub: /cities/coachella


### PR DESCRIPTION
## Summary
Enriches all 9 baseline city briefs with multiple official source entrypoints (2-4 each; currently 3 each) while preserving baseline/no-claim language.

## What changed
Updated these existing baseline briefs under `src/content/signals/`:
- 2025-12-01-palm-springs-ai-signal-scan-baseline.md
- 2025-12-02-desert-hot-springs-ai-signal-scan-baseline.md
- 2025-12-03-cathedral-city-ai-signal-scan-baseline.md
- 2025-12-04-rancho-mirage-ai-signal-scan-baseline.md
- 2025-12-05-palm-desert-ai-signal-scan-baseline.md
- 2025-12-06-indian-wells-ai-signal-scan-baseline.md
- 2025-12-07-indio-ai-signal-scan-baseline.md
- 2025-12-08-la-quinta-ai-signal-scan-baseline.md
- 2025-12-09-coachella-ai-signal-scan-baseline.md

For each brief:
- Frontmatter `sources` now includes multiple official URLs.
- Body `Sources` section now includes structured entries with:
  - URL
  - source type
  - short label
  - one-line notes
- No AI mention claims were added.

## Source types added across cities
- Agendas-Minutes
- Docs (City Clerk / Council records hubs)
- Video Archive
- YouTube (official city channels)

## Verification
- `npm run build` passes.
- Each baseline brief now renders with multiple official source entrypoints.
- Wording remains baseline-only and does not imply AI mentions.

## Vercel checks
- Preview URL: _to be added by Vercel on PR_
- Production target: https://aicoachellavalley-site.vercel.app
- Click paths:
  1. `/briefs` (open each 2025 baseline brief)
  2. `/state-of-ai/palm-springs` (confirmed signals shows enriched sources)
  3. Repeat for other city state pages as needed

## Notes
- Pre-cutover safe: no redirect/canonical changes were introduced.
