### PR TITLE
PR #7: Research ingestion schema + sample + validator

### DIFF
--- a/docs/research/2025/palm-springs.json
+++ b/docs/research/2025/palm-springs.json
@@ -1,0 +1,30 @@
+{
+  "citySlug": "palm-springs",
+  "year": 2025,
+  "lastScanDate": "2026-02-22",
+  "coverage": {
+    "meetingsScanned": null,
+    "transcriptsAvailable": null,
+    "documentsScanned": null,
+    "aiMentionsFound": null,
+    "notes": "Baseline ingest stub; counts will populate after automated scan ingestion is connected."
+  },
+  "sourcesScanned": [
+    {
+      "url": "https://www.palmspringsca.gov/government/city-council/city-council-meetings",
+      "type": "Agendas-Minutes",
+      "label": "City Council Meetings"
+    },
+    {
+      "url": "https://www.palmspringsca.gov/government/city-clerk",
+      "type": "Docs",
+      "label": "City Clerk Records"
+    },
+    {
+      "url": "https://www.youtube.com/@CityofPalmSprings",
+      "type": "YouTube",
+      "label": "City of Palm Springs Official Channel"
+    }
+  ],
+  "hits": []
+}

--- a/docs/research/SCHEMA.md
+++ b/docs/research/SCHEMA.md
@@ -1,0 +1,100 @@
+# Research Ingestion Schema (Docking Port)
+
+This format is the deterministic handoff for external research crawls and manual scans.
+
+## File location and naming
+
+- Directory: `docs/research/2025/`
+- File pattern: `docs/research/2025/{city-slug}.json`
+- Example: `docs/research/2025/palm-springs.json`
+
+`city-slug` must match a canonical slug in `src/data/cities.ts`.
+
+## Required top-level fields
+
+```json
+{
+  "citySlug": "palm-springs",
+  "year": 2025,
+  "lastScanDate": "2026-02-22",
+  "coverage": {
+    "meetingsScanned": null,
+    "transcriptsAvailable": null,
+    "documentsScanned": null,
+    "aiMentionsFound": null,
+    "notes": "Optional short note."
+  },
+  "sourcesScanned": [],
+  "hits": []
+}
+```
+
+- `citySlug`: string, required, must match `cities.ts`
+- `year`: number, required
+- `lastScanDate`: string `YYYY-MM-DD`, required
+- `coverage`: object, required
+- `sourcesScanned`: array, required
+- `hits`: array, required (can be empty)
+
+## `coverage` object
+
+Required keys:
+
+- `meetingsScanned`: number or `null`
+- `transcriptsAvailable`: number or `null`
+- `documentsScanned`: number or `null`
+- `aiMentionsFound`: number or `null`
+- `notes`: optional string
+
+Values may be `null` when unknown. Do not fabricate metrics.
+
+## `sourcesScanned` entries
+
+Array of:
+
+```json
+{
+  "url": "https://example.gov/path",
+  "type": "Agendas-Minutes",
+  "label": "City Council Agendas & Minutes"
+}
+```
+
+- `url`: required URL
+- `type`: required short source type label (`YouTube`, `Agendas-Minutes`, `Docs`, `Video Archive`, etc.)
+- `label`: required short label
+
+## `hits` entries
+
+Array of evidence hits (can be empty):
+
+```json
+{
+  "sourceUrl": "https://example.gov/doc.pdf",
+  "sourceType": "pdf",
+  "title": "City Council Agenda Packet",
+  "date": "2025-11-18",
+  "timestampOrPage": "p.14",
+  "snippet": "Short source-grounded excerpt or summary.",
+  "keywords": ["procurement", "software"],
+  "confidence": "med",
+  "notes": "Optional note."
+}
+```
+
+Required keys:
+
+- `sourceUrl`: URL
+- `sourceType`: one of `youtube | pdf | agenda | minutes | webpage`
+- `title`: string
+- `date`: `YYYY-MM-DD` or `null`
+- `timestampOrPage`: string or `null`
+- `snippet`: string (max 280 chars)
+- `keywords`: array of strings
+
+Optional keys:
+
+- `confidence`: `low | med | high`
+- `notes`: string
+
+Rule: no hit is valid without `sourceUrl`.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "audit:site": "node scripts/audit-site.mjs"
+    "audit:site": "node scripts/audit-site.mjs",
+    "validate:research": "node scripts/validate-research.mjs"
   },
   "dependencies": {
     "astro": "^5.17.1"

--- a/scripts/validate-research.mjs
+++ b/scripts/validate-research.mjs
@@ -1,0 +1,119 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const WORKDIR = process.cwd();
+const RESEARCH_DIR = path.join(WORKDIR, "docs", "research", "2025");
+const CITIES_FILE = path.join(WORKDIR, "src", "data", "cities.ts");
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const HIT_SOURCE_TYPES = new Set(["youtube", "pdf", "agenda", "minutes", "webpage"]);
+const COVERAGE_KEYS = [
+  "meetingsScanned",
+  "transcriptsAvailable",
+  "documentsScanned",
+  "aiMentionsFound",
+];
+
+const fail = (message) => {
+  throw new Error(message);
+};
+
+const assert = (condition, message) => {
+  if (!condition) fail(message);
+};
+
+const readCanonicalCitySlugs = () => {
+  assert(fs.existsSync(CITIES_FILE), `Missing canonical cities file: ${CITIES_FILE}`);
+  const content = fs.readFileSync(CITIES_FILE, "utf8");
+  const slugs = [...content.matchAll(/slug:\s*"([^"]+)"/g)].map((match) => match[1]);
+  assert(slugs.length > 0, "Could not parse city slugs from src/data/cities.ts");
+  return new Set(slugs);
+};
+
+const validateResearchFile = (filePath, citySlugSet) => {
+  const raw = fs.readFileSync(filePath, "utf8");
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (error) {
+    fail(`${filePath}: invalid JSON (${error instanceof Error ? error.message : String(error)})`);
+  }
+
+  const relPath = path.relative(WORKDIR, filePath);
+  const requiredTopLevel = ["citySlug", "year", "lastScanDate", "coverage", "sourcesScanned", "hits"];
+  requiredTopLevel.forEach((key) => {
+    assert(key in data, `${relPath}: missing required key "${key}"`);
+  });
+
+  assert(typeof data.citySlug === "string" && data.citySlug.length > 0, `${relPath}: citySlug must be a string`);
+  assert(citySlugSet.has(data.citySlug), `${relPath}: citySlug "${data.citySlug}" not found in src/data/cities.ts`);
+  assert(typeof data.year === "number", `${relPath}: year must be a number`);
+  assert(typeof data.lastScanDate === "string" && DATE_RE.test(data.lastScanDate), `${relPath}: lastScanDate must be YYYY-MM-DD`);
+  assert(typeof data.coverage === "object" && data.coverage !== null, `${relPath}: coverage must be an object`);
+  assert(Array.isArray(data.sourcesScanned), `${relPath}: sourcesScanned must be an array`);
+  assert(Array.isArray(data.hits), `${relPath}: hits must be an array`);
+
+  COVERAGE_KEYS.forEach((key) => {
+    assert(key in data.coverage, `${relPath}: coverage missing "${key}"`);
+    const value = data.coverage[key];
+    assert(value === null || typeof value === "number", `${relPath}: coverage.${key} must be number or null`);
+  });
+
+  data.sourcesScanned.forEach((source, index) => {
+    const ctx = `${relPath}: sourcesScanned[${index}]`;
+    assert(typeof source === "object" && source !== null, `${ctx} must be an object`);
+    assert(typeof source.url === "string" && source.url.startsWith("http"), `${ctx}.url must be a URL`);
+    assert(typeof source.type === "string" && source.type.length > 0, `${ctx}.type must be a non-empty string`);
+    assert(typeof source.label === "string" && source.label.length > 0, `${ctx}.label must be a non-empty string`);
+  });
+
+  data.hits.forEach((hit, index) => {
+    const ctx = `${relPath}: hits[${index}]`;
+    assert(typeof hit === "object" && hit !== null, `${ctx} must be an object`);
+    assert(typeof hit.sourceUrl === "string" && hit.sourceUrl.startsWith("http"), `${ctx}.sourceUrl is required and must be a URL`);
+    assert(typeof hit.sourceType === "string" && HIT_SOURCE_TYPES.has(hit.sourceType), `${ctx}.sourceType must be one of: ${Array.from(HIT_SOURCE_TYPES).join(", ")}`);
+    assert(typeof hit.title === "string" && hit.title.length > 0, `${ctx}.title must be a non-empty string`);
+    assert(hit.date === null || (typeof hit.date === "string" && DATE_RE.test(hit.date)), `${ctx}.date must be YYYY-MM-DD or null`);
+    assert(hit.timestampOrPage === null || typeof hit.timestampOrPage === "string", `${ctx}.timestampOrPage must be string or null`);
+    assert(typeof hit.snippet === "string" && hit.snippet.length > 0, `${ctx}.snippet is required`);
+    assert(hit.snippet.length <= 280, `${ctx}.snippet must be <= 280 chars`);
+    assert(Array.isArray(hit.keywords), `${ctx}.keywords must be an array`);
+    hit.keywords.forEach((keyword, keywordIndex) => {
+      assert(typeof keyword === "string" && keyword.length > 0, `${ctx}.keywords[${keywordIndex}] must be a non-empty string`);
+    });
+    if (hit.confidence !== undefined) {
+      assert(["low", "med", "high"].includes(hit.confidence), `${ctx}.confidence must be low, med, or high`);
+    }
+  });
+
+  return {
+    citySlug: data.citySlug,
+    hits: data.hits.length,
+    coverage: data.coverage,
+  };
+};
+
+const run = () => {
+  const citySlugSet = readCanonicalCitySlugs();
+  if (!fs.existsSync(RESEARCH_DIR)) {
+    fail(`Missing research directory: ${RESEARCH_DIR}`);
+  }
+
+  const files = fs
+    .readdirSync(RESEARCH_DIR)
+    .filter((entry) => entry.endsWith(".json"))
+    .map((entry) => path.join(RESEARCH_DIR, entry))
+    .sort((a, b) => a.localeCompare(b));
+
+  assert(files.length > 0, `No research JSON files found in ${path.relative(WORKDIR, RESEARCH_DIR)}`);
+
+  const summaries = files.map((file) => validateResearchFile(file, citySlugSet));
+
+  console.info(`[validate:research] Validated ${summaries.length} file(s).`);
+  summaries.forEach((summary) => {
+    const coverageKnown = COVERAGE_KEYS.filter((key) => typeof summary.coverage[key] === "number").length;
+    console.info(`- ${summary.citySlug}: hits=${summary.hits}, coverage_known=${coverageKnown}/${COVERAGE_KEYS.length}`);
+  });
+};
+
+run();


### PR DESCRIPTION
## Summary
Adds a minimal, deterministic research ingestion docking port:
- schema documentation
- one sample city file
- lightweight validator script for CI/local checks

No routing/canonical behavior changes.

## What shipped
- `docs/research/SCHEMA.md`
  - Defines file naming convention: `docs/research/2025/{city-slug}.json`
  - Defines required top-level fields and hit/source structures
  - Documents null-safe coverage rules and hit constraints
- `docs/research/2025/palm-springs.json`
  - Sample ingestion file using real official source entrypoints
  - Coverage metrics set to `null` baseline values
  - `hits` intentionally empty (no fabricated claims)
- `scripts/validate-research.mjs`
  - Validates all JSON files in `docs/research/2025/`
  - Checks `citySlug` against canonical slugs from `src/data/cities.ts`
  - Enforces required keys, coverage shape, and hit requirements (`sourceUrl`, `snippet`, etc.)
  - Throws on invalid files and logs per-city summary counts
- `package.json`
  - Adds script: `validate:research`

## Verification
- `npm run validate:research` ✅
- `npm run build` ✅
- No route behavior changes

## How to add a new city research file
1. Create `docs/research/2025/{city-slug}.json`.
2. Follow the exact structure in `docs/research/SCHEMA.md`.
3. Ensure `{city-slug}` exists in `src/data/cities.ts`.
4. Run `npm run validate:research`.

## How to run validator
- `npm run validate:research`

## Notes
- Coverage metrics allow `null`/unknown values.
- No fabricated metrics or AI-mention claims introduced.
