### PR TITLE
PR #8: Render research JSON on State of AI pages

### DIFF
--- a/src/pages/state-of-ai/[city].astro
+++ b/src/pages/state-of-ai/[city].astro
@@ -5,6 +5,7 @@ import PageHero from "../../components/PageHero.astro";
 import ResearchCoverage from "../../components/ResearchCoverage.astro";
 import { CITIES } from "../../data/cities";
 import { getCollection } from "astro:content";
+import { loadCityResearch } from "../../utils/researchLoader";
 import { normalizeMeta, resolveSummary } from "../../utils/briefs";
 
 export function getStaticPaths() {
@@ -21,12 +22,22 @@ if (!city) {
 }
 
 const allBriefs = await getCollection("signals");
+const research = await loadCityResearch({ citySlug: city.slug, year: 2025 });
 const confirmedBriefs = allBriefs
   .filter((brief) => normalizeMeta(brief.data.city) === city.slug)
   .filter((brief) => Array.isArray(brief.data.sources) && brief.data.sources.length > 0)
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 
-const lastUpdated = city.stateOfAI?.lastUpdated || new Date().toISOString().slice(0, 10);
+const lastUpdated = research?.lastScanDate || city.stateOfAI?.lastUpdated || new Date().toISOString().slice(0, 10);
+const coverage = research
+  ? {
+      meetingsScanned: research.coverage.meetingsScanned,
+      transcriptsAvailable: research.coverage.transcriptsAvailable,
+      documentsScanned: research.coverage.documentsScanned,
+      aiMentionsFound: research.coverage.aiMentionsFound,
+      lastScanDate: research.lastScanDate,
+    }
+  : city.stateOfAI?.coverage;
 const watchCategories = [
   "Procurement",
   "Workforce",
@@ -82,7 +93,31 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
 
   <section>
     <h2>Research Coverage</h2>
-    <ResearchCoverage coverage={city.stateOfAI?.coverage} />
+    <ResearchCoverage coverage={coverage} />
+  </section>
+
+  <section>
+    <h2>Confirmed public-source hits (from research)</h2>
+    {!research ? (
+      <p>Research scan in progress. Coverage metrics will appear here once logged.</p>
+    ) : research.hits.length === 0 ? (
+      <p>No confirmed hits logged yet for this city/year.</p>
+    ) : (
+      <div class="hits-grid">
+        {research.hits.map((hit) => (
+          <article class="signal-card">
+            <h3>{hit.title}</h3>
+            <p class="signal-meta">
+              {hit.date ? `Date: ${hit.date}` : "Date: Unknown"}
+              {hit.timestampOrPage ? ` · Location: ${hit.timestampOrPage}` : ""}
+              {` · Type: ${hit.sourceType}`}
+            </p>
+            <p>{hit.snippet}</p>
+            <p><a href={hit.sourceUrl} target="_blank" rel="noreferrer">Open source</a></p>
+          </article>
+        ))}
+      </div>
+    )}
   </section>
 
   <section>
@@ -138,6 +173,7 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
   }
 
   .signals-grid,
+  .hits-grid,
   .path-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));

--- a/src/utils/researchLoader.ts
+++ b/src/utils/researchLoader.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type ResearchHit = {
+  sourceUrl: string;
+  sourceType: "youtube" | "pdf" | "agenda" | "minutes" | "webpage";
+  title: string;
+  date: string | null;
+  timestampOrPage: string | null;
+  snippet: string;
+  keywords: string[];
+  confidence?: "low" | "med" | "high";
+  notes?: string;
+};
+
+export type CityResearchFile = {
+  citySlug: string;
+  year: number;
+  lastScanDate: string;
+  coverage: {
+    meetingsScanned: number | null;
+    transcriptsAvailable: number | null;
+    documentsScanned: number | null;
+    aiMentionsFound: number | null;
+    notes?: string;
+  };
+  sourcesScanned: Array<{
+    url: string;
+    type: string;
+    label: string;
+  }>;
+  hits: ResearchHit[];
+};
+
+export const loadCityResearch = async ({
+  citySlug,
+  year,
+}: {
+  citySlug: string;
+  year: number;
+}): Promise<CityResearchFile | null> => {
+  const filePath = path.join(process.cwd(), "docs", "research", String(year), `${citySlug}.json`);
+
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    return JSON.parse(raw) as CityResearchFile;
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: string }).code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw error;
+  }
+};


### PR DESCRIPTION
## Summary
Wires the research ingestion docking-port into State of AI pages (read-only):
- loads `docs/research/2025/{city}.json` when present
- renders ResearchCoverage from JSON coverage metrics
- renders a new "Confirmed public-source hits (from research)" section from `hits[]`

No brief generation in this PR.

## What changed
- Added loader utility: `src/utils/researchLoader.ts`
  - `loadCityResearch({ citySlug, year })`
  - returns parsed JSON object when file exists
  - returns `null` when file is missing (no throw)
- Updated city state page: `src/pages/state-of-ai/[city].astro`
  - Uses research JSON coverage when present
  - Falls back to existing placeholder coverage when missing
  - Adds hits section with three states:
    1. research missing: "Research scan in progress..."
    2. research present + no hits: "No confirmed hits logged yet..."
    3. research present + hits: list title/date/timestamp-snippet/source link

## Verification
- `npm run validate:research` ✅
- `npm run build` ✅
- No routing/canonical changes

## Vercel preview pages to click
1. City with research JSON:
   - `/state-of-ai/palm-springs`
   - Expect: coverage sourced from `docs/research/2025/palm-springs.json`; hits empty-state message
2. City without research JSON:
   - `/state-of-ai/indio`
   - Expect: in-progress message and placeholder coverage behavior (no errors)

## Notes
- This PR is intentionally scoped to rendering research JSON only; no automatic brief generation is included.
