### PR TITLE
PR #9: Deterministic brief generation from research hits

### DIFF
--- a/docs/research/2025/palm-springs.json
+++ b/docs/research/2025/palm-springs.json
@@ -26,5 +26,16 @@
       "label": "City of Palm Springs Official Channel"
     }
   ],
-  "hits": []
+  "hits": [
+    {
+      "sourceUrl": "https://www.palmspringsca.gov/government/city-council/city-council-meetings",
+      "sourceType": "webpage",
+      "title": "City Council Meetings",
+      "date": null,
+      "timestampOrPage": null,
+      "snippet": "The city meetings page links to council agenda packets, posted minutes, and meeting video access points.",
+      "keywords": ["agendas", "minutes", "meetings"],
+      "notes": "Baseline citation entrypoint; no AI mention claim."
+    }
+  ]
 }

--- a/docs/research/SCHEMA.md
+++ b/docs/research/SCHEMA.md
@@ -98,3 +98,18 @@ Optional keys:
 - `notes`: string
 
 Rule: no hit is valid without `sourceUrl`.
+
+## Generate Briefs From Hits
+
+Use the deterministic generator to convert `hits[]` into signal briefs:
+
+- Dry run (default): `npm run generate:briefs:research`
+- Explicit dry run: `npm run generate:briefs:research -- --dry-run`
+- Write files: `npm run generate:briefs:research -- --write`
+
+Behavior:
+
+- Reads all files in `docs/research/2025/`
+- Creates briefs in `src/content/signals/` from `hits[]`
+- Uses stable IDs to prevent duplicates on reruns
+- Skips collisions with existing human-authored briefs when source URL + timestamp/page matches

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "audit:site": "node scripts/audit-site.mjs",
-    "validate:research": "node scripts/validate-research.mjs"
+    "validate:research": "node scripts/validate-research.mjs",
+    "generate:briefs:research": "node scripts/generate-briefs-from-research.mjs"
   },
   "dependencies": {
     "astro": "^5.17.1"

--- a/scripts/generate-briefs-from-research.mjs
+++ b/scripts/generate-briefs-from-research.mjs
@@ -1,0 +1,202 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const WORKDIR = process.cwd();
+const RESEARCH_DIR = path.join(WORKDIR, "docs", "research", "2025");
+const SIGNALS_DIR = path.join(WORKDIR, "src", "content", "signals");
+const CITIES_FILE = path.join(WORKDIR, "src", "data", "cities.ts");
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const args = new Set(process.argv.slice(2));
+const shouldWrite = args.has("--write");
+const dryRun = !shouldWrite || args.has("--dry-run");
+
+const fail = (message) => {
+  throw new Error(message);
+};
+
+const readCitySlugSet = () => {
+  const citiesRaw = fs.readFileSync(CITIES_FILE, "utf8");
+  const slugs = [...citiesRaw.matchAll(/slug:\s*"([^"]+)"/g)].map((match) => match[1]);
+  return new Set(slugs);
+};
+
+const safeDate = (value) => (typeof value === "string" && DATE_RE.test(value) ? value : null);
+
+const slugPart = (text) =>
+  String(text || "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+const stableShortId = (hit) => {
+  const key = `${hit.sourceUrl}|${hit.title}|${hit.date || ""}|${hit.timestampOrPage || ""}`;
+  return crypto.createHash("sha256").update(key).digest("hex").slice(0, 10);
+};
+
+const toIsoDate = (hit, research) => {
+  if (safeDate(hit.date)) return { date: hit.date, dateUnknown: false };
+  if (safeDate(research.lastScanDate)) return { date: research.lastScanDate, dateUnknown: true };
+  return { date: "2025-01-01", dateUnknown: true };
+};
+
+const readResearchFiles = () => {
+  if (!fs.existsSync(RESEARCH_DIR)) return [];
+  return fs
+    .readdirSync(RESEARCH_DIR)
+    .filter((entry) => entry.endsWith(".json"))
+    .map((entry) => path.join(RESEARCH_DIR, entry))
+    .sort((a, b) => a.localeCompare(b));
+};
+
+const readExistingSignalFiles = () => {
+  if (!fs.existsSync(SIGNALS_DIR)) return [];
+  return fs
+    .readdirSync(SIGNALS_DIR)
+    .filter((entry) => entry.endsWith(".md"))
+    .map((entry) => ({
+      name: entry,
+      path: path.join(SIGNALS_DIR, entry),
+      content: fs.readFileSync(path.join(SIGNALS_DIR, entry), "utf8"),
+    }));
+};
+
+const hasHumanCollision = (existingFiles, hit) => {
+  return existingFiles.some((file) => {
+    if (file.name.includes("research-hit-")) return false;
+    const hasSource = file.content.includes(hit.sourceUrl);
+    if (!hasSource) return false;
+    if (!hit.timestampOrPage) return false;
+    return file.content.includes(hit.timestampOrPage);
+  });
+};
+
+const buildFrontmatter = ({ title, date, citySlug, summary, hit, sourceMeta, research, dateUnknown }) => {
+  const sourceType = sourceMeta?.type || "webpage";
+  const sourceLabel = sourceMeta?.label || hit.title;
+  const sourceNotes = sourceMeta?.notes || "Logged from research ingestion hit.";
+  const confidence =
+    hit.confidence === "low" ? "low" : hit.confidence === "high" ? "high" : "medium";
+
+  return `---
+title: "${title.replace(/"/g, '\\"')}"
+date: ${date}
+city: ${citySlug}
+sector: Public Sector
+signal_type: research
+confidence: ${confidence}
+tags:
+  - research-hit
+  - state-of-ai-2025
+sources:
+  - url: ${hit.sourceUrl}
+    type: ${sourceType}
+    label: "${sourceLabel.replace(/"/g, '\\"')}"
+    notes: "${sourceNotes.replace(/"/g, '\\"')}"
+summary: "${summary.replace(/"/g, '\\"')}"
+dateUnknown: ${dateUnknown ? "true" : "false"}
+evidence:
+  timestampOrPage: ${hit.timestampOrPage ? `"${hit.timestampOrPage.replace(/"/g, '\\"')}"` : "null"}
+  snippet: "${hit.snippet.replace(/"/g, '\\"')}"
+research:
+  year: ${research.year}
+  citySlug: ${research.citySlug}
+  lastScanDate: "${research.lastScanDate}"
+---
+`;
+};
+
+const buildBody = ({ hit, date }) => `This brief records a source-grounded research hit captured from a public document or recording. Logged snippet: "${hit.snippet}".
+
+## Source
+- URL: ${hit.sourceUrl}
+- Date: ${hit.date || date}
+- Timestamp/Page: ${hit.timestampOrPage || "Not provided"}
+
+## Why this matters
+This entry preserves traceable evidence context so city-level AI tracking can reference a dated source location without adding unsupported claims.
+`;
+
+const run = () => {
+  const citySlugSet = readCitySlugSet();
+  const researchFiles = readResearchFiles();
+  if (researchFiles.length === 0) fail(`No research files found in ${path.relative(WORKDIR, RESEARCH_DIR)}`);
+
+  const existingFiles = readExistingSignalFiles();
+  const existingGeneratedNames = new Set(existingFiles.filter((f) => f.name.includes("research-hit-")).map((f) => f.name));
+  const outputs = [];
+  const cityStats = new Map();
+
+  for (const filePath of researchFiles) {
+    const raw = fs.readFileSync(filePath, "utf8");
+    const research = JSON.parse(raw);
+    if (!citySlugSet.has(research.citySlug)) fail(`${filePath}: unknown citySlug ${research.citySlug}`);
+    if (!Array.isArray(research.hits)) fail(`${filePath}: hits must be an array`);
+
+    const stats = cityStats.get(research.citySlug) || { processed: 0, toWrite: 0, skippedExisting: 0, skippedCollision: 0 };
+
+    for (const hit of research.hits) {
+      stats.processed += 1;
+      if (!hit?.sourceUrl || !hit?.snippet) fail(`${filePath}: each hit must include sourceUrl and snippet`);
+
+      const shortId = stableShortId(hit);
+      const resolved = toIsoDate(hit, research);
+      const [year, month, day] = resolved.date.split("-");
+      const filename = `${year}-${month}-${day}-${slugPart(research.citySlug)}-research-hit-${shortId}.md`;
+      const outPath = path.join(SIGNALS_DIR, filename);
+
+      if (existingGeneratedNames.has(filename) || fs.existsSync(outPath)) {
+        stats.skippedExisting += 1;
+        continue;
+      }
+
+      if (hasHumanCollision(existingFiles, hit)) {
+        stats.skippedCollision += 1;
+        continue;
+      }
+
+      const sourceMeta = (research.sourcesScanned || []).find((source) => source.url === hit.sourceUrl);
+      const title = `Research hit: ${hit.title}`;
+      const summary = `Source-grounded hit logged from ${hit.sourceType} evidence for ${research.citySlug}: ${hit.snippet}`.slice(0, 250);
+      const frontmatter = buildFrontmatter({
+        title,
+        date: resolved.date,
+        citySlug: research.citySlug,
+        summary,
+        hit,
+        sourceMeta,
+        research,
+        dateUnknown: resolved.dateUnknown,
+      });
+      const body = buildBody({ hit, date: resolved.date });
+
+      outputs.push({ path: outPath, content: `${frontmatter}\n${body}\n` });
+      stats.toWrite += 1;
+    }
+
+    cityStats.set(research.citySlug, stats);
+  }
+
+  console.info(`[generate:briefs:research] mode=${dryRun ? "dry-run" : "write"}`);
+  for (const [citySlug, stats] of cityStats.entries()) {
+    console.info(
+      `- ${citySlug}: hits=${stats.processed}, to_write=${stats.toWrite}, skipped_existing=${stats.skippedExisting}, skipped_collision=${stats.skippedCollision}`
+    );
+  }
+  console.info(`[generate:briefs:research] total new files: ${outputs.length}`);
+
+  if (!dryRun) {
+    outputs.forEach((output) => {
+      fs.writeFileSync(output.path, output.content, "utf8");
+    });
+    console.info(`[generate:briefs:research] wrote ${outputs.length} file(s).`);
+  } else {
+    outputs.slice(0, 5).forEach((output) => {
+      console.info(`  dry-run would write: ${path.relative(WORKDIR, output.path)}`);
+    });
+  }
+};
+
+run();

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,15 @@
 import { defineCollection, z } from "astro:content";
 
+const sourceEntry = z.union([
+  z.string().url(),
+  z.object({
+    url: z.string().url(),
+    type: z.string().optional(),
+    label: z.string().optional(),
+    notes: z.string().optional(),
+  }),
+]);
+
 const signals = defineCollection({
   type: "content",
   schema: z.object({
@@ -17,9 +27,23 @@ const signals = defineCollection({
       "research",
     ]),
     confidence: z.enum(["low", "medium", "high"]),
-    sources: z.array(z.string().url()).optional(),
+    sources: z.array(sourceEntry).optional(),
     tags: z.array(z.string()).optional(),
     summary: z.string(),
+    dateUnknown: z.boolean().optional(),
+    evidence: z
+      .object({
+        timestampOrPage: z.string().nullable().optional(),
+        snippet: z.string().optional(),
+      })
+      .optional(),
+    research: z
+      .object({
+        year: z.number(),
+        citySlug: z.string(),
+        lastScanDate: z.string(),
+      })
+      .optional(),
   }),
 });
 

--- a/src/content/signals/2026-02-22-palm-springs-research-hit-540943f715.md
+++ b/src/content/signals/2026-02-22-palm-springs-research-hit-540943f715.md
@@ -1,0 +1,35 @@
+---
+title: "Research hit: City Council Meetings"
+date: 2026-02-22
+city: palm-springs
+sector: Public Sector
+signal_type: research
+confidence: medium
+tags:
+  - research-hit
+  - state-of-ai-2025
+sources:
+  - url: https://www.palmspringsca.gov/government/city-council/city-council-meetings
+    type: Agendas-Minutes
+    label: "City Council Meetings"
+    notes: "Logged from research ingestion hit."
+summary: "Source-grounded hit logged from webpage evidence for palm-springs: The city meetings page links to council agenda packets, posted minutes, and meeting video access points."
+dateUnknown: true
+evidence:
+  timestampOrPage: null
+  snippet: "The city meetings page links to council agenda packets, posted minutes, and meeting video access points."
+research:
+  year: 2025
+  citySlug: palm-springs
+  lastScanDate: "2026-02-22"
+---
+
+This brief records a source-grounded research hit captured from a public document or recording. Logged snippet: "The city meetings page links to council agenda packets, posted minutes, and meeting video access points.".
+
+## Source
+- URL: https://www.palmspringsca.gov/government/city-council/city-council-meetings
+- Date: 2026-02-22
+- Timestamp/Page: Not provided
+
+## Why this matters
+This entry preserves traceable evidence context so city-level AI tracking can reference a dated source location without adding unsupported claims.

--- a/src/pages/briefs/[slug].astro
+++ b/src/pages/briefs/[slug].astro
@@ -86,6 +86,17 @@ const relatedBriefs = allBriefs
   })
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
   .slice(0, 3);
+
+const normalizedSources = (brief.data.sources ?? []).map((source) =>
+  typeof source === "string"
+    ? { url: source, label: source, type: "", notes: "" }
+    : {
+        url: source.url,
+        label: source.label || source.url,
+        type: source.type || "",
+        notes: source.notes || "",
+      }
+);
 ---
 
 <BaseLayout title={`${brief.data.title} | Briefs`}>
@@ -109,12 +120,16 @@ const relatedBriefs = allBriefs
     <hr />
     <Content />
 
-    {brief.data.sources && brief.data.sources.length > 0 ? (
+    {normalizedSources.length > 0 ? (
       <>
         <h2>Sources</h2>
         <ul>
-          {brief.data.sources.map((url) => (
-            <li><a href={url} target="_blank" rel="noreferrer">{url}</a></li>
+          {normalizedSources.map((source) => (
+            <li>
+              <a href={source.url} target="_blank" rel="noreferrer">{source.label}</a>
+              {source.type ? ` (${source.type})` : ""}
+              {source.notes ? ` - ${source.notes}` : ""}
+            </li>
           ))}
         </ul>
       </>

--- a/src/pages/signals/[slug].astro
+++ b/src/pages/signals/[slug].astro
@@ -24,6 +24,17 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
   month: "long",
   day: "2-digit",
 });
+
+const normalizedSources = (signal.data.sources ?? []).map((source) =>
+  typeof source === "string"
+    ? { url: source, label: source, type: "", notes: "" }
+    : {
+        url: source.url,
+        label: source.label || source.url,
+        type: source.type || "",
+        notes: source.notes || "",
+      }
+);
 ---
 
 <BaseLayout title={`${signal.data.title} | Briefs`}>
@@ -52,12 +63,16 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
     <hr />
     <Content />
 
-    {signal.data.sources && signal.data.sources.length > 0 ? (
+    {normalizedSources.length > 0 ? (
       <>
         <h2>Sources</h2>
         <ul>
-          {signal.data.sources.map((url) => (
-            <li><a href={url} target="_blank" rel="noreferrer">{url}</a></li>
+          {normalizedSources.map((source) => (
+            <li>
+              <a href={source.url} target="_blank" rel="noreferrer">{source.label}</a>
+              {source.type ? ` (${source.type})` : ""}
+              {source.notes ? ` - ${source.notes}` : ""}
+            </li>
           ))}
         </ul>
       </>

--- a/src/pages/state-of-ai/[city].astro
+++ b/src/pages/state-of-ai/[city].astro
@@ -81,8 +81,15 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
             <p>{resolveSummary(brief)}</p>
             <h4>Sources</h4>
             <ul class="source-list">
-              {(brief.data.sources || []).map((url) => (
-                <li><a href={url} target="_blank" rel="noreferrer">{url}</a></li>
+              {(brief.data.sources || []).map((source) => (
+                typeof source === "string" ? (
+                  <li><a href={source} target="_blank" rel="noreferrer">{source}</a></li>
+                ) : (
+                  <li>
+                    <a href={source.url} target="_blank" rel="noreferrer">{source.label || source.url}</a>
+                    {source.type ? ` (${source.type})` : ""}
+                  </li>
+                )
               ))}
             </ul>
           </article>


### PR DESCRIPTION
## Summary
Adds a deterministic generator that converts research `hits[]` into real signal briefs (no manual copy/paste), with collision protection and dry-run mode.

Generated briefs now flow into:
- `/briefs`
- `/cities/<slug>` (city counts/feeds)
- `/state-of-ai/<slug>` confirmed signals

## What shipped
- New script: `scripts/generate-briefs-from-research.mjs`
  - Reads all `docs/research/2025/*.json`
  - Creates stable short IDs from `sourceUrl + title + date + timestampOrPage`
  - Deterministic filename pattern:
    - `YYYY-MM-DD-{citySlug}-research-hit-{shortid}.md`
  - Supports:
    - `--dry-run` (default behavior unless `--write`)
    - `--write` (writes files)
  - Skip rules:
    - skips when generated file already exists
    - skips on source/timestamp collision with human-authored briefs
- npm script:
  - `generate:briefs:research`
- Schema/docs updates:
  - `docs/research/SCHEMA.md` now includes “How to generate briefs”
- Added one sample hit to:
  - `docs/research/2025/palm-springs.json`
- Generated one research-hit brief via script write mode:
  - `src/content/signals/2026-02-22-palm-springs-research-hit-540943f715.md`

## Compatibility updates
To support generated structured source metadata while preserving existing briefs:
- `src/content.config.ts` now accepts `sources` entries as either URL strings or structured objects
- Source rendering updated in:
  - `src/pages/briefs/[slug].astro`
  - `src/pages/signals/[slug].astro`
  - `src/pages/state-of-ai/[city].astro`

## How to run
1. Validate research files:
   - `npm run validate:research`
2. Preview generation:
   - `npm run generate:briefs:research -- --dry-run`
3. Write generated briefs:
   - `npm run generate:briefs:research -- --write`

## Dry-run output example
```text
[generate:briefs:research] mode=dry-run
- palm-springs: hits=1, to_write=1, skipped_existing=0, skipped_collision=0
[generate:briefs:research] total new files: 1
  dry-run would write: src/content/signals/2026-02-22-palm-springs-research-hit-540943f715.md
```

After write + rerun dry-run:
```text
[generate:briefs:research] mode=dry-run
- palm-springs: hits=1, to_write=0, skipped_existing=1, skipped_collision=0
[generate:briefs:research] total new files: 0
```

## Verification
- `npm run validate:research` ✅
- `npm run generate:briefs:research -- --dry-run` ✅
- `npm run generate:briefs:research -- --write` ✅
- `npm run build` ✅

## Vercel pages to verify
1. `/briefs` (includes generated research-hit brief)
2. `/cities/palm-springs` (brief count reflects generated brief)
3. `/state-of-ai/palm-springs` (confirmed signals includes generated brief)

## Notes
- No routing/canonical changes were introduced.
- Generator is deterministic and safe to rerun.
