### PR TITLE
PR #10: CI guardrails for research ingestion and brief generation

### DIFF
--- a/.github/workflows/research-ingestion.yml
+++ b/.github/workflows/research-ingestion.yml
@@ -1,0 +1,57 @@
+name: Research Ingestion Guardrails
+
+on:
+  pull_request:
+    paths:
+      - "docs/research/**"
+      - "scripts/generate-briefs-from-research.*"
+      - "src/content/signals/**"
+      - "src/content.config.ts"
+
+jobs:
+  research-guardrails:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate research JSON
+        run: npm run validate:research
+
+      - name: Run generator dry-run
+        run: |
+          set -euo pipefail
+          npm run generate:briefs:research -- --dry-run | tee /tmp/research-dry-run.log
+
+      - name: Enforce generated briefs committed
+        run: |
+          set -euo pipefail
+          SUMMARY_LINE="$(grep 'RESEARCH_GENERATION_SUMMARY=' /tmp/research-dry-run.log | tail -n 1 || true)"
+          if [ -z "$SUMMARY_LINE" ]; then
+            echo "Missing RESEARCH_GENERATION_SUMMARY line in generator output."
+            exit 1
+          fi
+
+          SUMMARY_JSON="${SUMMARY_LINE#RESEARCH_GENERATION_SUMMARY=}"
+          TO_WRITE="$(node -e "const s=JSON.parse(process.argv[1]); process.stdout.write(String((s.to_write ?? \"\")));" "$SUMMARY_JSON")"
+
+          if [ -z "$TO_WRITE" ]; then
+            echo "Could not parse to_write from RESEARCH_GENERATION_SUMMARY."
+            exit 1
+          fi
+
+          if [ "$TO_WRITE" -gt 0 ]; then
+            echo "Research hits would generate new briefs. Run generator with --write and commit generated markdown files."
+            exit 1
+          fi
+
+          echo "Research ingestion guardrail passed (to_write=$TO_WRITE)."

--- a/docs/research/SCHEMA.md
+++ b/docs/research/SCHEMA.md
@@ -113,3 +113,12 @@ Behavior:
 - Creates briefs in `src/content/signals/` from `hits[]`
 - Uses stable IDs to prevent duplicates on reruns
 - Skips collisions with existing human-authored briefs when source URL + timestamp/page matches
+
+## PR Checklist
+
+When a PR changes research files or research-hit generation inputs:
+
+1. Run `npm run validate:research`
+2. Run `npm run generate:briefs:research -- --write`
+3. Commit generated markdown outputs under `src/content/signals/`
+4. Ensure CI dry-run reports `to_write=0`


### PR DESCRIPTION
## Summary
Adds CI guardrails for research ingestion so PRs are operator-proof:
- research JSON must validate
- generator dry-run must be parseable
- PR fails if dry-run indicates new briefs should be generated but are not committed

CI is dry-run only (no file writes/commits).

## What changed
- Added workflow: `.github/workflows/research-ingestion.yml`
  - Trigger: `pull_request` with paths:
    - `docs/research/**`
    - `scripts/generate-briefs-from-research.*`
    - `src/content/signals/**`
    - `src/content.config.ts`
  - Steps:
    - setup Node 20
    - `npm ci`
    - `npm run validate:research`
    - `npm run generate:briefs:research -- --dry-run`
    - parse generator summary and fail if `to_write > 0`
  - Failure message:
    - `Research hits would generate new briefs. Run generator with --write and commit generated markdown files.`
- Updated generator output (`scripts/generate-briefs-from-research.mjs`)
  - Adds machine-parseable final line:
    - `RESEARCH_GENERATION_SUMMARY={...}`
- Updated docs checklist (`docs/research/SCHEMA.md`)
  - Added PR checklist requiring validate + write + commit generated outputs

## Verification
- `npm run generate:briefs:research -- --dry-run` ✅
  - includes: `RESEARCH_GENERATION_SUMMARY={"mode":"dry-run",...}`
- `npm run validate:research` ✅
- `npm run build` ✅

## CI behavior expected
- PR touching research inputs without committed generated briefs (when `to_write > 0`) -> **fails** with guardrail message.
- PR with generated briefs committed (`to_write = 0`) -> **passes**.

## Notes
- No routing/canonical changes.
- CI does not write or commit files.
