### PR TITLE
PR #11: Add How AICV Works methodology page

### DIFF
--- a/src/pages/how-it-works.astro
+++ b/src/pages/how-it-works.astro
@@ -1,0 +1,89 @@
+---
+import ActionCard from "../components/ActionCard.astro";
+import BaseLayout from "../layouts/BaseLayout.astro";
+import PageHero from "../components/PageHero.astro";
+---
+
+<BaseLayout
+  title="How AICV Works | AI Coachella Valley"
+  description="An evidence-first publishing engine for Coachella Valley AI signal."
+>
+  <PageHero
+    title="How AICV Works"
+    description="An evidence-first publishing engine for Coachella Valley AI signal."
+  />
+
+  <section>
+    <h2>The ladder</h2>
+    <ol class="ladder">
+      <li>Briefs</li>
+      <li>City Hubs</li>
+      <li>State of AI</li>
+      <li>Programs/Tools</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>Evidence rules</h2>
+    <ul class="rule-list">
+      <li>Sources required</li>
+      <li>No URL = no claim</li>
+      <li>We separate coverage from conclusions</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Update cycle</h2>
+    <ol class="cycle-list">
+      <li>Public sources are scanned.</li>
+      <li>Findings are logged as structured research.</li>
+      <li>Evidence briefs are generated and reviewed.</li>
+      <li>Pages update with timestamps and a changelog mindset.</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>Top Paths</h2>
+    <div class="path-grid">
+      <ActionCard
+        title="Browse State of AI"
+        description="Review city-level narrative snapshots backed by source evidence."
+        href="/state-of-ai"
+        buttonLabel="Open State of AI"
+      />
+      <ActionCard
+        title="Browse Cities"
+        description="Navigate city hubs with briefs and current coverage context."
+        href="/cities"
+        buttonLabel="Open Cities"
+      />
+      <ActionCard
+        title="Submit a Brief"
+        description="Contribute source-backed local evidence for review."
+        href="/submit"
+        buttonLabel="Open Submit a Brief"
+      />
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  section + section {
+    margin-top: var(--s-6);
+  }
+
+  .ladder,
+  .rule-list,
+  .cycle-list {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: var(--s-2);
+  }
+
+  .path-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    gap: var(--s-4);
+  }
+</style>

--- a/src/pages/start-here.astro
+++ b/src/pages/start-here.astro
@@ -27,6 +27,12 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     <h2>Top Paths</h2>
     <div class="path-grid">
       <ActionCard
+        title="How AICV Works"
+        description="Read the evidence-first methodology and publishing runbook."
+        href="/how-it-works"
+        buttonLabel="Open How AICV Works"
+      />
+      <ActionCard
         title="Browse Cities"
         description="Navigate city-by-city evidence hubs."
         href="/cities"


### PR DESCRIPTION
## Summary
Adds a human-facing methodology/runbook page (`/how-it-works`) and links it from Start Here to make the evidence-first system easier to understand and cite.

## What changed
- Added: `src/pages/how-it-works.astro`
  - Hero: “How AICV Works”
  - Ladder: Briefs → City Hubs → State of AI → Programs/Tools
  - Evidence rules:
    - Sources required
    - No URL = no claim
    - Coverage separated from conclusions
  - Update cycle summary
  - Action cards to `/state-of-ai`, `/cities`, `/submit`
- Updated: `src/pages/start-here.astro`
  - Added ActionCard linking to `/how-it-works`

## Verification
- `npm run build` ✅
- `/how-it-works` renders with shared components/tokens ✅
- Start Here links to `/how-it-works` ✅
- No new 404s introduced ✅

## Vercel preview pages to click
1. `/how-it-works`
2. `/start-here` (open “How AICV Works” card)
3. `/state-of-ai`
4. `/cities`
5. `/submit`

## Notes
- No new nav item added (linked from Start Here as requested).
- No routing/canonical behavior changes beyond adding `/how-it-works`.
